### PR TITLE
HttpSession中间件:新增sessionid自定义获取方式

### DIFF
--- a/src/Server/Session/Middleware/HttpSessionMiddleware.php
+++ b/src/Server/Session/Middleware/HttpSessionMiddleware.php
@@ -20,7 +20,7 @@ class HttpSessionMiddleware implements MiddlewareInterface
      *
      * @var callable
      */
-    protected $sessionIDHandle = null;
+    protected $sessionIdHandler = null;
 
     /**
      * Process an incoming server request and return a response, optionally delegating
@@ -31,8 +31,8 @@ class HttpSessionMiddleware implements MiddlewareInterface
         $sessionManager = RequestContext::getBean('SessionManager');
 
         $sessionID = '';
-        if($this->sessionIDHandle !== null && is_callable($this->sessionIDHandle)){
-            $sessionID = call_user_func($this->sessionIDHandle,$request);
+        if(null !== $this->sessionIdHandler && is_callable($this->sessionIdHandler)) {
+            $sessionID = ($this->sessionIdHandler)($request);
         }
         $sessionID = $sessionID ?: $request->getCookie($sessionManager->getName());
 

--- a/src/Server/Session/Middleware/HttpSessionMiddleware.php
+++ b/src/Server/Session/Middleware/HttpSessionMiddleware.php
@@ -16,13 +16,25 @@ use Imi\Server\Http\Message\Response;
 class HttpSessionMiddleware implements MiddlewareInterface
 {
     /**
+     * SessionID处理器
+     *
+     * @var callable
+     */
+    protected $sessionIDHandle = null;
+
+    /**
      * Process an incoming server request and return a response, optionally delegating
      * response creation to a handler.
      */
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
         $sessionManager = RequestContext::getBean('SessionManager');
-        $sessionID = $request->getCookie($sessionManager->getName());
+
+        $sessionID = '';
+        if($this->sessionIDHandle !== null && is_callable($this->sessionIDHandle)){
+            $sessionID = call_user_func($this->sessionIDHandle,$request);
+        }
+        $sessionID = $sessionID ?: $request->getCookie($sessionManager->getName());
 
         // 开启session
         $this->start($sessionManager, $sessionID);


### PR DESCRIPTION
默认通过cookie头获取
[4种PHP回调函数风格](https://wiki.swoole.com/wiki/page/458.html)
```php
return [
    'beans' => [
         \Imi\Server\Session\Middleware\HttpSessionMiddleware::class => 'your callback'//回调参数为当前Request对象
    ]
];
```