### PR TITLE
修复 whereBrackets() 返回一个 Where 对象时值绑定无效

### DIFF
--- a/src/Db/Query/Where/WhereBrackets.php
+++ b/src/Db/Query/Where/WhereBrackets.php
@@ -102,7 +102,10 @@ class WhereBrackets extends BaseWhere implements IWhereBrackets
         }
         elseif ($callResult instanceof IBaseWhere)
         {
-            return $callResult->toStringWithoutLogic($query);
+            $result = $callResult->toStringWithoutLogic($query);
+            $binds = array_merge($binds, $callResult->getBinds());
+
+            return $result;
         }
         else
         {


### PR DESCRIPTION
fix #259