### PR TITLE
修复存在多个空 WhereBrackets 时构建错误

### DIFF
--- a/src/Db/Query/Builder/BaseBuilder.php
+++ b/src/Db/Query/Builder/BaseBuilder.php
@@ -120,13 +120,14 @@ abstract class BaseBuilder implements IBuilder
             }
         }
         unset($result[0]);
-        $result = implode(' ', $result);
-        if ('' !== $result)
+        if ($result)
         {
-            $result = ' where ' . $result;
+            return ' where ' . implode(' ', $result);
         }
-
-        return $result;
+        else
+        {
+            return '';
+        }
     }
 
     /**

--- a/src/Db/Query/Builder/BaseBuilder.php
+++ b/src/Db/Query/Builder/BaseBuilder.php
@@ -107,7 +107,7 @@ abstract class BaseBuilder implements IBuilder
         foreach ($where as $item)
         {
             $sql = $item->toStringWithoutLogic($query);
-            if (empty($sql))
+            if ('' === $sql)
             {
                 continue;
             }

--- a/src/Db/Query/Builder/BaseBuilder.php
+++ b/src/Db/Query/Builder/BaseBuilder.php
@@ -122,15 +122,12 @@ abstract class BaseBuilder implements IBuilder
         unset($result[0]);
         if ($result)
         {
-            $result = implode(' ', $result);
-            $result = ' where ' . $result;
+            return ' where ' . implode(' ', $result);
         }
         else
         {
-            $result = '';
+            return '';
         }
-
-        return $result;
     }
 
     /**

--- a/src/Db/Query/Builder/BaseBuilder.php
+++ b/src/Db/Query/Builder/BaseBuilder.php
@@ -106,8 +106,13 @@ abstract class BaseBuilder implements IBuilder
         $query = $this->query;
         foreach ($where as $item)
         {
+            $sql = $item->toStringWithoutLogic($query);
+            if (empty($sql))
+            {
+                continue;
+            }
             $result[] = $item->getLogicalOperator();
-            $result[] = $item->toStringWithoutLogic($query);
+            $result[] = $sql;
             $binds = $item->getBinds();
             if ($binds)
             {
@@ -115,10 +120,14 @@ abstract class BaseBuilder implements IBuilder
             }
         }
         unset($result[0]);
-        $result = implode(' ', $result);
-        if ('' !== $result)
+        if ($result)
         {
+            $result = implode(' ', $result);
             $result = ' where ' . $result;
+        }
+        else
+        {
+            $result = '';
         }
 
         return $result;

--- a/src/Db/Query/Builder/BaseBuilder.php
+++ b/src/Db/Query/Builder/BaseBuilder.php
@@ -120,14 +120,13 @@ abstract class BaseBuilder implements IBuilder
             }
         }
         unset($result[0]);
-        if ($result)
+        $result = implode(' ', $result);
+        if ('' !== $result)
         {
-            return ' where ' . implode(' ', $result);
+            $result = ' where ' . $result;
         }
-        else
-        {
-            return '';
-        }
+
+        return $result;
     }
 
     /**


### PR DESCRIPTION
1. 修复错误
```
\Imi\Db\Db::query()
    ->table('test')
    ->whereBrackets(fn() => [])
    ->whereBrackets(fn() => [])
    ->select();
```
2. 如果`implode`返回不为空，那构建结果必然是有数据的，则应该可以通过判断构建结果数组是否空跳过执行`implode`