### PR TITLE
优化错误报告

### DIFF
--- a/doc/base/config.md
+++ b/doc/base/config.md
@@ -146,6 +146,8 @@ return [
             'reactor_num'	    => 8,
             'worker_num'	    => 8,
             'task_worker_num'	=> 16,
+            // Swoole 错误日志文件。如果不设置或为null则自动记录到 .runtime/swoole/swoole.log。如果设为 false 不记录 Swoole 错误日志。
+            // 'log_file' => '',
         ],
         // 服务器容器绑定
         'beans' => [

--- a/doc/core/handleError.md
+++ b/doc/core/handleError.md
@@ -7,9 +7,7 @@ imi 框架底层支持将错误转为异常，可以通过 `try...catch` 来捕�
 ```php
 [
     'ErrorLog'  =>  [
-        // PHP 报告的错误级别，默认 0，不报告任何信息
-        'level' =>  0,
-        // 'level' =>  E_ALL, // 报告所有错误
+        // 'level' =>  E_ALL, // 报告所有错误，这是默认值
         // 'level' =>  E_ALL & ~E_NOTICE, // 报告 E_NOTICE 之外的所有错误
 
         // 错误捕获级别，捕获到的错误都会做处理，此为默认值

--- a/src/Components/swoole/src/Server/Base.php
+++ b/src/Components/swoole/src/Server/Base.php
@@ -94,6 +94,15 @@ abstract class Base extends BaseServer implements ISwooleServer
             {
                 $configs['pid_file'] = Imi::getRuntimePath('swoole.pid');
             }
+            if (!isset($configs['log_file']))
+            {
+                $configs['log_file'] = Imi::getRuntimePath('swoole.log');
+            }
+            elseif (false === $configs['log_file'])
+            {
+                // 设为 false 可以禁用 Swoole 错误日志文件
+                unset($configs['log_file']);
+            }
             $this->swooleServer->set($configs);
         }
         $this->bindEvents();

--- a/src/Log/ErrorLog.php
+++ b/src/Log/ErrorLog.php
@@ -17,7 +17,7 @@ class ErrorLog
     /**
      * PHP 报告的错误级别.
      */
-    protected int $level = 0;
+    protected int $level = \E_ALL;
 
     /**
      * 错误捕获级别.


### PR DESCRIPTION
* 更改默认的 PHP 报告的错误级别为 E_ALL
* Swoole 服务器如果不配置 `log_file` 将自动记录到 `.runtime/swoole/swoole.log`