### PR TITLE
新增 `Imi\dump()` 调试输出函数

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -40,6 +40,7 @@ return (new PhpCsFixer\Config())
         'heredoc_indentation'        => [
             'indentation' => 'same_as_start',
         ],
+        'no_trailing_whitespace_in_string' => false,
     ])
     ->setRiskyAllowed(true)
     ->setFinder(

--- a/doc/base/version/2.0-2.1.md
+++ b/doc/base/version/2.0-2.1.md
@@ -12,6 +12,10 @@ v2.1 版本相比 v2.0 版本不会出现非常大的不兼容更改，可以参
 
 ## 新功能
 
+### v2.1.7
+
+* [新增 `Imi\dump()` 调试输出函数](/v2.1/utils/functions.md#Imi\dump)
+
 ### v2.1.6
 
 * [支持在 composer.json 中配置项目命名空间](/v2.1/base/config.html#%E5%85%B1%E6%9C%89%E7%BB%93%E6%9E%84)

--- a/doc/utils/functions.md
+++ b/doc/utils/functions.md
@@ -1,6 +1,6 @@
 # 全局函数
 
-### imigo
+## imigo
 
 启动一个协程，自动创建和销毁上下文
 
@@ -19,7 +19,7 @@ imigo(function($id, $name){
 }, 1, 'test');
 ```
 
-### imiCallable
+## imiCallable
 
 为传入的回调自动创建和销毁上下文，并返回新的回调
 
@@ -47,7 +47,7 @@ function test($a)
 test($callable);
 ```
 
-### imiGetEnv
+## imiGetEnv
 
 获取环境变量值
 
@@ -55,13 +55,13 @@ test($callable);
 
 > 将在 imi v3.0.0 废弃，请使用 `Imi\env()`
 
-### Imi\env
+## Imi\env
 
 获取环境变量值
 
 定义：`env($varname = null, $default = null, $localOnly = false);`
 
-### Imi\cmd
+## Imi\cmd
 
 处理命令行，执行后不会有 sh 进程
 
@@ -69,7 +69,7 @@ test($callable);
 echo \Imi\cmd('ls');
 ```
 
-### Imi\ttyExec
+## Imi\ttyExec
 
 尝试使用 tty 模式执行命令，可以保持带颜色格式的输出
 
@@ -86,3 +86,20 @@ echo \Imi\cmd('ls');
 ```
 
 超时会抛出异常：`\Symfony\Component\Process\Exception\ProcessTimedOutException`
+
+## Imi\dump
+
+调试输出函数，用法同 `var_dump()`。
+
+cli 模式运行时，会通过 `Log::debug()` 来记录运行结果。
+
+例：
+
+```php
+\Imi\dump('Hello imi!');
+```
+
+```log
+[2022-03-21 16:21:34] imi.DEBUG: 
+string(10) "Hello imi!"
+```

--- a/tests/unit/Component/Tests/FunctionTest.php
+++ b/tests/unit/Component/Tests/FunctionTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Imi\Test\Component\Tests;
+
+use Imi\Test\BaseTest;
+use Imi\Util\File;
+use Imi\Util\Imi;
+use Symfony\Component\Process\Process;
+
+class FunctionTest extends BaseTest
+{
+    public function testDump(): void
+    {
+        $cmd = [
+            \PHP_BINARY,
+            File::path(\dirname(Imi::getNamespacePath('Imi')), 'src', 'Cli', 'bin', 'imi-cli'),
+            '--app-namespace',
+            'Imi\Test\Component',
+            'TestTool/testDump',
+        ];
+
+        $process = new Process($cmd, \dirname(Imi::getNamespacePath('Imi')));
+        $process->mustRun();
+        $output = $process->getOutput();
+        $this->assertTrue(str_contains($output, <<<'STR'
+        imi.DEBUG: 
+        string(10) "Hello imi!"
+        STR));
+    }
+}

--- a/tests/unit/Component/Tests/FunctionTest.php
+++ b/tests/unit/Component/Tests/FunctionTest.php
@@ -24,9 +24,9 @@ class FunctionTest extends BaseTest
         $process = new Process($cmd, \dirname(Imi::getNamespacePath('Imi')));
         $process->mustRun();
         $output = $process->getOutput();
-        $this->assertTrue(str_contains($output, <<<'STR'
-        imi.DEBUG: 
-        string(10) "Hello imi!"
-        STR));
+        $this->assertTrue(false !== preg_match(<<<'STR'
+        /imi\.DEBUG: [\r\n]+
+        string(10) "Hello imi!"/
+        STR, $output), 'output: ' . $output);
     }
 }

--- a/tests/unit/Component/Tool/TestTool.php
+++ b/tests/unit/Component/Tool/TestTool.php
@@ -10,6 +10,7 @@ use Imi\Cli\Annotation\CommandAction;
 use Imi\Cli\Annotation\Option;
 use Imi\Cli\ArgType;
 use Imi\Cli\Contract\BaseCommand;
+use function Imi\dump;
 
 /**
  * @Command("TestTool")
@@ -62,5 +63,13 @@ class TestTool extends BaseCommand
     {
         var_dump($test);
         var_dump($this->input->getOption('test'));
+    }
+
+    /**
+     * @CommandAction(name="testDump")
+     */
+    public function testDump(): void
+    {
+        dump('Hello imi!');
     }
 }


### PR DESCRIPTION
调试输出函数，用法同 `var_dump()`。

cli 模式运行时，会通过 `Log::debug()` 来记录运行结果。

例：

```php
\Imi\dump('Hello imi!');
```

```log
[2022-03-21 16:21:34] imi.DEBUG: 
string(10) "Hello imi!"
```