### PR TITLE
改进 where in 对空数组的支持、解决 batchInsert 插入无下标0成员的数组时报错

### DIFF
--- a/src/Components/pgsql/src/Db/Query/Builder/BatchInsertBuilder.php
+++ b/src/Components/pgsql/src/Db/Query/Builder/BatchInsertBuilder.php
@@ -29,7 +29,7 @@ class BatchInsertBuilder extends BaseBuilder
         {
             throw new \RuntimeException('Batch insert must have at least 1 data');
         }
-        $fields = array_keys($list[array_key_first($list)]);
+        $fields = array_keys(reset($list));
         $safeFields = [];
         foreach ($fields as $key)
         {

--- a/src/Components/pgsql/src/Db/Query/Builder/BatchInsertBuilder.php
+++ b/src/Components/pgsql/src/Db/Query/Builder/BatchInsertBuilder.php
@@ -29,7 +29,7 @@ class BatchInsertBuilder extends BaseBuilder
         {
             throw new \RuntimeException('Batch insert must have at least 1 data');
         }
-        $fields = array_keys($list[0]);
+        $fields = array_keys($list[array_key_first($list)]);
         $safeFields = [];
         foreach ($fields as $key)
         {

--- a/src/Db/Mysql/Query/Builder/BatchInsertBuilder.php
+++ b/src/Db/Mysql/Query/Builder/BatchInsertBuilder.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Imi\Db\Mysql\Query\Builder;
 
-use function array_key_first;
 use Imi\Db\Query\QueryOption;
 use Imi\Util\ObjectArrayHelper;
 
@@ -30,7 +29,7 @@ class BatchInsertBuilder extends BaseBuilder
         {
             throw new \RuntimeException('Batch insert must have at least 1 data');
         }
-        $fields = array_keys($list[array_key_first($list)]);
+        $fields = array_keys(reset($list));
         $safeFields = [];
         foreach ($fields as $key)
         {

--- a/src/Db/Mysql/Query/Builder/BatchInsertBuilder.php
+++ b/src/Db/Mysql/Query/Builder/BatchInsertBuilder.php
@@ -6,6 +6,7 @@ namespace Imi\Db\Mysql\Query\Builder;
 
 use Imi\Db\Query\QueryOption;
 use Imi\Util\ObjectArrayHelper;
+use function array_key_first;
 
 class BatchInsertBuilder extends BaseBuilder
 {
@@ -29,7 +30,7 @@ class BatchInsertBuilder extends BaseBuilder
         {
             throw new \RuntimeException('Batch insert must have at least 1 data');
         }
-        $fields = array_keys($list[0]);
+        $fields = array_keys($list[array_key_first($list)]);
         $safeFields = [];
         foreach ($fields as $key)
         {

--- a/src/Db/Mysql/Query/Builder/BatchInsertBuilder.php
+++ b/src/Db/Mysql/Query/Builder/BatchInsertBuilder.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Imi\Db\Mysql\Query\Builder;
 
+use function array_key_first;
 use Imi\Db\Query\QueryOption;
 use Imi\Util\ObjectArrayHelper;
-use function array_key_first;
 
 class BatchInsertBuilder extends BaseBuilder
 {

--- a/src/Db/Query/Interfaces/IQuery.php
+++ b/src/Db/Query/Interfaces/IQuery.php
@@ -538,7 +538,7 @@ interface IQuery
 
     /**
      * 批量插入数据
-     * 以第 0 个成员作为字段标准.
+     * 以首个成员作为字段标准.
      *
      * @param array|object|null $data
      */

--- a/src/Db/Query/Where/Where.php
+++ b/src/Db/Query/Where/Where.php
@@ -154,11 +154,7 @@ class Where extends BaseWhere implements IWhere
                 $valueNames = [];
                 if (\is_array($thisValues))
                 {
-                    if (0 === \count($thisValues))
-                    {
-                        $result .= '(' . ('in' === $operation ? '0 = 1' : '1 = 1') . ')';
-                    }
-                    else
+                    if ($thisValues)
                     {
                         foreach ($thisValues as $value)
                         {
@@ -167,6 +163,10 @@ class Where extends BaseWhere implements IWhere
                             $binds[$paramName] = $value;
                         }
                         $result .= '(' . implode(',', $valueNames) . ')';
+                    }
+                    else
+                    {
+                        $result .= '(' . ('in' === $operation ? '0 = 1' : '1 = 1') . ')';
                     }
                 }
                 elseif ($thisValues instanceof Raw)

--- a/src/Db/Query/Where/Where.php
+++ b/src/Db/Query/Where/Where.php
@@ -9,7 +9,6 @@ use Imi\Db\Query\Interfaces\IQuery;
 use Imi\Db\Query\Interfaces\IWhere;
 use Imi\Db\Query\Raw;
 use Imi\Db\Query\Traits\TRaw;
-use function count;
 
 class Where extends BaseWhere implements IWhere
 {
@@ -155,9 +154,9 @@ class Where extends BaseWhere implements IWhere
                 $valueNames = [];
                 if (\is_array($thisValues))
                 {
-                    if (count($thisValues) === 0)
+                    if (0 === \count($thisValues))
                     {
-                        $result .= '(' . ($operation === 'in' ? '0 = 1' : '1 = 1') . ')';
+                        $result .= '(' . ('in' === $operation ? '0 = 1' : '1 = 1') . ')';
                     }
                     else
                     {

--- a/src/Db/Query/Where/Where.php
+++ b/src/Db/Query/Where/Where.php
@@ -9,6 +9,7 @@ use Imi\Db\Query\Interfaces\IQuery;
 use Imi\Db\Query\Interfaces\IWhere;
 use Imi\Db\Query\Raw;
 use Imi\Db\Query\Traits\TRaw;
+use function count;
 
 class Where extends BaseWhere implements IWhere
 {
@@ -151,21 +152,27 @@ class Where extends BaseWhere implements IWhere
                 break;
             case 'in':
             case 'not in':
-                $result .= '(';
                 $valueNames = [];
                 if (\is_array($thisValues))
                 {
-                    foreach ($thisValues as $value)
+                    if (count($thisValues) === 0)
                     {
-                        $paramName = $query->getAutoParamName();
-                        $valueNames[] = $paramName;
-                        $binds[$paramName] = $value;
+                        $result .= '(' . ($operation === 'in' ? '0 = 1' : '1 = 1') . ')';
                     }
-                    $result .= implode(',', $valueNames) . ')';
+                    else
+                    {
+                        foreach ($thisValues as $value)
+                        {
+                            $paramName = $query->getAutoParamName();
+                            $valueNames[] = $paramName;
+                            $binds[$paramName] = $value;
+                        }
+                        $result .= '(' . implode(',', $valueNames) . ')';
+                    }
                 }
                 elseif ($thisValues instanceof Raw)
                 {
-                    $result .= $thisValues->toString($query) . ')';
+                    $result .= '(' . $thisValues->toString($query) . ')';
                 }
                 else
                 {

--- a/tests/unit/Component/Tests/Db/DbBaseTest.php
+++ b/tests/unit/Component/Tests/Db/DbBaseTest.php
@@ -607,4 +607,19 @@ abstract class DbBaseTest extends BaseTest
             ],
         ], $stmt->fetchAll());
     }
+
+    public function testWhereInEmptyValue()
+    {
+        $sql = Db::query()->table('test1')
+            ->whereIn('a1', [1, 2, 3])
+            ->whereIn('a2', [])
+            ->whereNotIn('a3', [1, 2, 3])
+            ->whereNotIn('a4', [])
+            ->buildSelectSql();
+
+        $this->assertEquals(
+            'select * from `test1` where `a1` in (:p1,:p2,:p3) and `a2` in (0 = 1) and `a3` not in (:p4,:p5,:p6) and `a4` not in (1 = 1)',
+            $sql
+        );
+    }
 }

--- a/tests/unit/Component/Tests/Db/DbBaseTest.php
+++ b/tests/unit/Component/Tests/Db/DbBaseTest.php
@@ -397,7 +397,7 @@ abstract class DbBaseTest extends BaseTest
         $time = time();
         for ($i = 1; $i <= $insertCount; ++$i)
         {
-            $data[] = [
+            $data["k_{$i}"] = [
                 'title'     => "title_{$i}",
                 'content'   => "content_{$i}",
                 'time'      => date('Y-m-d H:i:s', $time + $i),

--- a/tests/unit/Component/Tests/Db/DbBaseTest.php
+++ b/tests/unit/Component/Tests/Db/DbBaseTest.php
@@ -608,7 +608,7 @@ abstract class DbBaseTest extends BaseTest
         ], $stmt->fetchAll());
     }
 
-    public function testWhereInEmptyValue()
+    public function testWhereInEmptyValue(): void
     {
         $sql = Db::query()->table('test1')
             ->whereIn('a1', [1, 2, 3])


### PR DESCRIPTION
- [改进 where in 对空数组的支持](https://github.com/imiphp/imi/commit/12b56ca265d6ac777db2fd0d0fbdce53a624bb1a)
- [解决 batchInsert 插入无下标0成员的数组时报错](https://github.com/imiphp/imi/commit/ecd4e6b406eba71372fbfa8c69b22e1b2f487adc)