### PR TITLE
修复特定情况下 Result->isSuccess() 结果不正确

### DIFF
--- a/src/Components/pgsql/src/Db/Drivers/PdoPgsql/Driver.php
+++ b/src/Components/pgsql/src/Db/Drivers/PdoPgsql/Driver.php
@@ -114,6 +114,7 @@ class Driver extends PgsqlBase
             {
                 return true;
             }
+            // @phpstan-ignore-next-line
             if ($this->checkCodeIsOffline($instance->errorCode() ?? ''))
             {
                 $this->close();
@@ -175,6 +176,7 @@ class Driver extends PgsqlBase
         {
             if (!$this->inTransaction() && !$this->instance->beginTransaction())
             {
+                // @phpstan-ignore-next-line
                 if ($this->checkCodeIsOffline($this->instance->errorCode() ?? ''))
                 {
                     $this->close();
@@ -206,6 +208,7 @@ class Driver extends PgsqlBase
         {
             if (!$this->instance->commit())
             {
+                // @phpstan-ignore-next-line
                 if ($this->checkCodeIsOffline($this->instance->errorCode() ?? ''))
                 {
                     $this->close();
@@ -255,6 +258,7 @@ class Driver extends PgsqlBase
         {
             $this->transaction->rollBack($levels);
         }
+        // @phpstan-ignore-next-line
         elseif ($this->checkCodeIsOffline($this->instance->errorCode() ?? ''))
         {
             $this->close();

--- a/src/Components/pgsql/src/Db/Drivers/PdoPgsql/Driver.php
+++ b/src/Components/pgsql/src/Db/Drivers/PdoPgsql/Driver.php
@@ -114,7 +114,7 @@ class Driver extends PgsqlBase
             {
                 return true;
             }
-            if ($this->checkCodeIsOffline($instance->errorInfo()[0] ?? ''))
+            if ($this->checkCodeIsOffline($instance->errorCode() ?? ''))
             {
                 $this->close();
             }
@@ -175,7 +175,7 @@ class Driver extends PgsqlBase
         {
             if (!$this->inTransaction() && !$this->instance->beginTransaction())
             {
-                if ($this->checkCodeIsOffline($this->instance->errorInfo()[0] ?? ''))
+                if ($this->checkCodeIsOffline($this->instance->errorCode() ?? ''))
                 {
                     $this->close();
                 }
@@ -206,7 +206,7 @@ class Driver extends PgsqlBase
         {
             if (!$this->instance->commit())
             {
-                if ($this->checkCodeIsOffline($this->instance->errorInfo()[0] ?? ''))
+                if ($this->checkCodeIsOffline($this->instance->errorCode() ?? ''))
                 {
                     $this->close();
                 }
@@ -255,7 +255,7 @@ class Driver extends PgsqlBase
         {
             $this->transaction->rollBack($levels);
         }
-        elseif ($this->checkCodeIsOffline($this->instance->errorInfo()[0] ?? ''))
+        elseif ($this->checkCodeIsOffline($this->instance->errorCode() ?? ''))
         {
             $this->close();
         }
@@ -338,7 +338,7 @@ class Driver extends PgsqlBase
             {
                 $errorCode = $this->errorCode();
                 $errorInfo = $this->errorInfo();
-                if ($this->checkCodeIsOffline($this->instance->errorInfo()[0] ?? ''))
+                if ($this->checkCodeIsOffline($errorCode))
                 {
                     $this->close();
                 }
@@ -425,7 +425,7 @@ class Driver extends PgsqlBase
                 {
                     $errorCode = $this->errorCode();
                     $errorInfo = $this->errorInfo();
-                    if ($this->checkCodeIsOffline($this->instance->errorInfo()[0] ?? ''))
+                    if ($this->checkCodeIsOffline($errorCode))
                     {
                         $this->close();
                     }
@@ -463,7 +463,7 @@ class Driver extends PgsqlBase
             {
                 $errorCode = $this->errorCode();
                 $errorInfo = $this->errorInfo();
-                if ($this->checkCodeIsOffline($this->instance->errorInfo()[0] ?? ''))
+                if ($this->checkCodeIsOffline($errorCode))
                 {
                     $this->close();
                 }

--- a/src/Components/pgsql/src/Db/Drivers/PdoPgsql/Statement.php
+++ b/src/Components/pgsql/src/Db/Drivers/PdoPgsql/Statement.php
@@ -152,7 +152,7 @@ class Statement extends PgsqlBaseStatement implements IPgsqlStatement
                 $errorCode = $this->errorCode();
                 $errorInfo = $this->errorInfo();
                 $db = $this->db;
-                if ($db->checkCodeIsOffline($db->errorInfo()[0] ?? ''))
+                if ($db->checkCodeIsOffline($errorCode))
                 {
                     $db->close();
                 }

--- a/src/Db/Db.php
+++ b/src/Db/Db.php
@@ -350,7 +350,7 @@ class Db
             $stmt = $db->query($sql);
         }
 
-        return new Result($stmt);
+        return new Result($stmt, null, true);
     }
 
     /**

--- a/src/Db/Mysql/Drivers/PdoMysql/Driver.php
+++ b/src/Db/Mysql/Drivers/PdoMysql/Driver.php
@@ -119,7 +119,7 @@ class Driver extends MysqlBase
             {
                 return true;
             }
-            if ($this->checkCodeIsOffline($instance->errorInfo()[1] ?? 0))
+            if ($this->checkCodeIsOffline((int) $instance->errorCode()))
             {
                 $this->close();
             }
@@ -180,7 +180,7 @@ class Driver extends MysqlBase
         {
             if (!$this->inTransaction() && !$this->instance->beginTransaction())
             {
-                if ($this->checkCodeIsOffline($this->instance->errorInfo()[1] ?? 0))
+                if ($this->checkCodeIsOffline((int) $this->instance->errorCode()))
                 {
                     $this->close();
                 }
@@ -211,7 +211,7 @@ class Driver extends MysqlBase
         {
             if (!$this->instance->commit())
             {
-                if ($this->checkCodeIsOffline($this->instance->errorInfo()[1] ?? 0))
+                if ($this->checkCodeIsOffline((int) $this->instance->errorCode()))
                 {
                     $this->close();
                 }
@@ -260,7 +260,7 @@ class Driver extends MysqlBase
         {
             $this->transaction->rollBack($levels);
         }
-        elseif ($this->checkCodeIsOffline($this->instance->errorInfo()[1] ?? 0))
+        elseif ($this->checkCodeIsOffline((int) $this->instance->errorCode()))
         {
             $this->close();
         }
@@ -343,7 +343,7 @@ class Driver extends MysqlBase
             {
                 $errorCode = $this->errorCode();
                 $errorInfo = $this->errorInfo();
-                if ($this->checkCodeIsOffline($this->instance->errorInfo()[1] ?? 0))
+                if ($this->checkCodeIsOffline((int) $errorCode))
                 {
                     $this->close();
                 }
@@ -429,7 +429,7 @@ class Driver extends MysqlBase
                 {
                     $errorCode = $this->errorCode();
                     $errorInfo = $this->errorInfo();
-                    if ($this->checkCodeIsOffline($this->instance->errorInfo()[1] ?? 0))
+                    if ($this->checkCodeIsOffline((int) $errorCode))
                     {
                         $this->close();
                     }
@@ -467,7 +467,7 @@ class Driver extends MysqlBase
             {
                 $errorCode = $this->errorCode();
                 $errorInfo = $this->errorInfo();
-                if ($this->checkCodeIsOffline($this->instance->errorInfo()[1] ?? 0))
+                if ($this->checkCodeIsOffline((int) $errorCode))
                 {
                     $this->close();
                 }

--- a/src/Db/Mysql/Drivers/PdoMysql/Statement.php
+++ b/src/Db/Mysql/Drivers/PdoMysql/Statement.php
@@ -151,7 +151,7 @@ class Statement extends MysqlBaseStatement implements IMysqlStatement
             {
                 $errorCode = $this->errorCode();
                 $errorInfo = $this->errorInfo();
-                if ($this->db->checkCodeIsOffline($this->db->errorInfo()[1] ?? 0))
+                if ($this->db->checkCodeIsOffline((int) $errorCode))
                 {
                     $this->db->close();
                 }

--- a/src/Db/Query/Query.php
+++ b/src/Db/Query/Query.php
@@ -867,7 +867,7 @@ abstract class Query implements IQuery
             $this->binds = [];
             $stmt->execute($binds);
 
-            return new $resultClass($stmt, $this->modelClass);
+            return new $resultClass($stmt, $this->modelClass, true);
         }
         finally
         {

--- a/src/Db/Query/Result.php
+++ b/src/Db/Query/Result.php
@@ -38,13 +38,13 @@ class Result implements IResult
     /**
      * @param \Imi\Db\Interfaces\IStatement|bool $statement
      */
-    public function __construct($statement, ?string $modelClass = null)
+    public function __construct($statement, ?string $modelClass = null, ?bool $success = null)
     {
         $this->modelClass = $modelClass;
         if ($statement instanceof IStatement)
         {
             $this->statement = $statement;
-            $this->isSuccess = '' === $statement->errorInfo();
+            $this->isSuccess = null === $success ? ('' === $statement->errorInfo()) : $success;
             if ($statement->columnCount() > 0)
             {
                 $this->statementRecords = $statement->fetchAll();

--- a/src/Db/Query/Result.php
+++ b/src/Db/Query/Result.php
@@ -44,7 +44,7 @@ class Result implements IResult
         if ($statement instanceof IStatement)
         {
             $this->statement = $statement;
-            $this->isSuccess = null === $success ? ('' === $statement->errorInfo()) : $success;
+            $this->isSuccess = ($success ?? ('' === $statement->errorInfo()));
             if ($statement->columnCount() > 0)
             {
                 $this->statementRecords = $statement->fetchAll();


### PR DESCRIPTION
PDO 的 `query` 两次调用分别是：失败、成功，第二次获取到的 `errorInfo()` 是预期的空
PDO 的 `Statement->execute()` 两次调用分别是：失败、成功，第二次获取到的 `errorInfo()` 是上次的错误信息

mysqli 没有这个问题

Swoole 协程 MySQL 客户端同样有这个问题，但大佬认为这不是 bug，而是特性……

所以只能框架层面做处理