### PR TITLE
修复模型和数据库查询结果对象的 getArray() 方法，传 $className 时的兼容性

### DIFF
--- a/src/Db/Query/Result.php
+++ b/src/Db/Query/Result.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Imi\Db\Query;
 
+use Imi\Bean\BeanFactory;
 use Imi\Db\Interfaces\IStatement;
 use Imi\Db\Query\Interfaces\IResult;
 use Imi\Db\Query\Result\TResultEntityCreate;
@@ -178,7 +179,11 @@ class Result implements IResult
             $list = [];
             foreach ($this->statementRecords as $item)
             {
-                $list[] = new $className($item);
+                $list[] = $row = BeanFactory::newInstance($className, $item);
+                foreach ($item as $k => $v)
+                {
+                    $row->$k = $v;
+                }
             }
 
             return $list;

--- a/src/Model/ModelQueryResult.php
+++ b/src/Model/ModelQueryResult.php
@@ -246,7 +246,11 @@ class ModelQueryResult extends Result
             $list = [];
             foreach ($this->statementRecords as $item)
             {
-                $list[] = new $className($item);
+                $list[] = $row = BeanFactory::newInstance($className, $item);
+                foreach ($item as $k => $v)
+                {
+                    $row->$k = $v;
+                }
             }
 
             return $list;

--- a/tests/unit/Component/Partial/Partial/TPartialClassA1.php
+++ b/tests/unit/Component/Partial/Partial/TPartialClassA1.php
@@ -3,36 +3,19 @@
 declare(strict_types=1);
 
 namespace Imi\Test\Component\Partial\Partial
+;
+
+use Imi\Bean\Annotation\Partial;
+
+/**
+ * @Partial(Imi\Test\Component\Partial\Classes\PartialClassA::class)
+ */
+trait TPartialClassA1
 {
-    use Imi\Bean\Annotation\Partial;
+    public int $test2Value = 2;
 
-    /**
-     * @Partial(Imi\Test\Component\Partial\Classes\PartialClassA::class)
-     */
-    trait TPartialClassA1
+    public function test2(): int
     {
-        public int $test2Value = 2;
-
-        public function test2(): int
-        {
-            return $this->test2Value;
-        }
-    }
-}
-
-namespace Imi\Test\Component\Partial\Classes
-{
-    // @phpstan-ignore-next-line
-    if (false)
-    {
-        class PartialClassA
-        {
-            public int $test2Value;
-
-            public function test2(): int
-            {
-                return 0;
-            }
-        }
+        return $this->test2Value;
     }
 }

--- a/tests/unit/Component/Partial/Partial/TPartialClassA2.php
+++ b/tests/unit/Component/Partial/Partial/TPartialClassA2.php
@@ -3,37 +3,19 @@
 declare(strict_types=1);
 
 namespace Imi\Test\Component\Partial\Partial
+;
+
+use Imi\Bean\Annotation\Partial;
+
+/**
+ * @Partial(Imi\Test\Component\Partial\Classes\PartialClassA::class)
+ */
+trait TPartialClassA2
 {
-    use Imi\Bean\Annotation\Partial;
+    private int $test3Value = 3;
 
-    /**
-     * @Partial(Imi\Test\Component\Partial\Classes\PartialClassA::class)
-     */
-    trait TPartialClassA2
+    public function test3(): int
     {
-        private int $test3Value = 3;
-
-        public function test3(): int
-        {
-            return $this->test3Value;
-        }
-    }
-}
-
-namespace Imi\Test\Component\Partial\Classes
-{
-    // @phpstan-ignore-next-line
-    if (false)
-    {
-        class PartialClassA
-        {
-            // @phpstan-ignore-next-line
-            private int $test3Value;
-
-            public function test3(): int
-            {
-                return 0;
-            }
-        }
+        return $this->test3Value;
     }
 }


### PR DESCRIPTION
`Result` 中的 `get()`、`getArray()` 跟随 PDO 的 `fetchObject` 逻辑，采用对属性赋值的形式初始化对象，而不是依赖构造方法。

修改的地方暂时不去掉构造方法的参数，保持兼容性，3.0 中移除。