### PR TITLE
对 int、float、bool 类型配置参数值进行类型转换

### DIFF
--- a/src/Components/amqp/src/Pool/AMQPCoroutinePool.php
+++ b/src/Components/amqp/src/Pool/AMQPCoroutinePool.php
@@ -39,11 +39,11 @@ class AMQPCoroutinePool extends BaseAsyncPool
         $config = $this->getNextResourceConfig();
         if (isset($config['heartbeat']))
         {
-            $heartbeat = $config['heartbeat'];
+            $heartbeat = (int) $config['heartbeat'];
         }
         elseif (($poolHeartbeatInterval = $this->getConfig()->getHeartbeatInterval()) > 0)
         {
-            $heartbeat = $poolHeartbeatInterval * 2;
+            $heartbeat = (int) ($poolHeartbeatInterval * 2);
         }
         else
         {
@@ -51,6 +51,6 @@ class AMQPCoroutinePool extends BaseAsyncPool
         }
         $class = $config['connectionClass'] ?? AMQPSwooleConnection::class;
 
-        return BeanFactory::newInstance(AMQPResource::class, $this, new $class($config['host'], $config['port'], $config['user'], $config['password'], $config['vhost'] ?? '/', $config['insist'] ?? false, $config['loginMethod'] ?? 'AMQPLAIN', $config['loginResponse'] ?? null, $config['locale'] ?? 'en_US', $config['connectionTimeout'] ?? 3.0, $config['readWriteTimeout'] ?? 3.0, $config['context'] ?? null, $config['keepalive'] ?? false, $heartbeat, $config['channelRpcTimeout'] ?? 0.0));
+        return BeanFactory::newInstance(AMQPResource::class, $this, new $class($config['host'], (int) $config['port'], $config['user'], $config['password'], $config['vhost'] ?? '/', (bool) ($config['insist'] ?? false), $config['loginMethod'] ?? 'AMQPLAIN', $config['loginResponse'] ?? null, $config['locale'] ?? 'en_US', (float) ($config['connectionTimeout'] ?? 3.0), (float) ($config['readWriteTimeout'] ?? 3.0), $config['context'] ?? null, (bool) ($config['keepalive'] ?? false), $heartbeat, (float) ($config['channelRpcTimeout'] ?? 0.0)));
     }
 }

--- a/src/Components/amqp/src/Pool/AMQPPool.php
+++ b/src/Components/amqp/src/Pool/AMQPPool.php
@@ -44,7 +44,7 @@ class AMQPPool
             }
 
             /** @var AbstractConnection $connection */
-            $connection = App::newInstance($config['connectionClass'] ?? AMQPStreamConnection::class, $config['host'], $config['port'], $config['user'], $config['password'], $config['vhost'] ?? '/', $config['insist'] ?? false, $config['loginMethod'] ?? 'AMQPLAIN', $config['loginResponse'] ?? null, $config['locale'] ?? 'en_US', $config['connectionTimeout'] ?? 3.0, $config['readWriteTimeout'] ?? 3.0, $config['context'] ?? null, $config['keepalive'] ?? false, $config['heartbeat'] ?? 0, $config['channelRpcTimeout'] ?? 0.0, $config['sslProtocol'] ?? null);
+            $connection = App::newInstance($config['connectionClass'] ?? AMQPStreamConnection::class, $config['host'], (int) $config['port'], $config['user'], $config['password'], $config['vhost'] ?? '/', (bool) ($config['insist'] ?? false), $config['loginMethod'] ?? 'AMQPLAIN', $config['loginResponse'] ?? null, $config['locale'] ?? 'en_US', (float) ($config['connectionTimeout'] ?? 3.0), (float) ($config['readWriteTimeout'] ?? 3.0), $config['context'] ?? null, (bool) ($config['keepalive'] ?? false), (int) ($config['heartbeat'] ?? 0), (float) ($config['channelRpcTimeout'] ?? 0.0), $config['sslProtocol'] ?? null);
             if (!$connection->isConnected())
             {
                 throw new \RuntimeException(sprintf('AMQP %s connection failed', $poolName));
@@ -86,7 +86,7 @@ class AMQPPool
             if (null === $connection || !$connection->isConnected())
             {
                 /** @var AbstractConnection $connection */
-                $connection = App::newInstance($config['connectionClass'] ?? AMQPStreamConnection::class, $config['host'], $config['port'], $config['user'], $config['password'], $config['vhost'] ?? '/', $config['insist'] ?? false, $config['loginMethod'] ?? 'AMQPLAIN', $config['loginResponse'] ?? null, $config['locale'] ?? 'en_US', $config['connectionTimeout'] ?? 3.0, $config['readWriteTimeout'] ?? 3.0, $config['context'] ?? null, $config['keepalive'] ?? false, $config['heartbeat'] ?? 0, $config['channelRpcTimeout'] ?? 0.0, $config['sslProtocol'] ?? null);
+                $connection = App::newInstance($config['connectionClass'] ?? AMQPStreamConnection::class, $config['host'], (int) $config['port'], $config['user'], $config['password'], $config['vhost'] ?? '/', (bool) ($config['insist'] ?? false), $config['loginMethod'] ?? 'AMQPLAIN', $config['loginResponse'] ?? null, $config['locale'] ?? 'en_US', (float) ($config['connectionTimeout'] ?? 3.0), (float) ($config['readWriteTimeout'] ?? 3.0), $config['context'] ?? null, (bool) ($config['keepalive'] ?? false), (int) ($config['heartbeat'] ?? 0), (float) ($config['channelRpcTimeout'] ?? 0.0), $config['sslProtocol'] ?? null);
                 if (!$connection->isConnected())
                 {
                     throw new \RuntimeException(sprintf('AMQP %s connection failed', $poolName));

--- a/src/Components/amqp/src/Pool/AMQPSyncPool.php
+++ b/src/Components/amqp/src/Pool/AMQPSyncPool.php
@@ -37,7 +37,7 @@ class AMQPSyncPool extends BaseSyncPool
     public function createNewResource(): IPoolResource
     {
         $config = $this->getNextResourceConfig();
-        $connection = new AMQPStreamConnection($config['host'], $config['port'], $config['user'], $config['password'], $config['vhost'] ?? '/', $config['insist'] ?? false, $config['loginMethod'] ?? 'AMQPLAIN', $config['loginResponse'] ?? null, $config['locale'] ?? 'en_US', $config['connectionTimeout'] ?? 3.0, $config['readWriteTimeout'] ?? 3.0, $config['context'] ?? null, $config['keepalive'] ?? false, $config['heartbeat'] ?? 0, $config['channelRpcTimeout'] = 0.0, $config['sslProtocol'] ?? null);
+        $connection = new AMQPStreamConnection($config['host'], (int) $config['port'], $config['user'], $config['password'], $config['vhost'] ?? '/', (bool) ($config['insist'] ?? false), $config['loginMethod'] ?? 'AMQPLAIN', $config['loginResponse'] ?? null, $config['locale'] ?? 'en_US', (float) ($config['connectionTimeout'] ?? 3.0), (float) ($config['readWriteTimeout'] ?? 3.0), $config['context'] ?? null, (bool) ($config['keepalive'] ?? false), (int) ($config['heartbeat'] ?? 0), (float) ($config['channelRpcTimeout'] = 0.0), $config['sslProtocol'] ?? null);
 
         return BeanFactory::newInstance(AMQPResource::class, $this, $connection);
     }

--- a/src/Components/grpc/src/Client/GrpcClient.php
+++ b/src/Components/grpc/src/Client/GrpcClient.php
@@ -68,7 +68,10 @@ class GrpcClient implements IRpcClient
         $this->url = $options['url'];
         $this->uri = new Uri($this->url);
         $this->requestMethod = $options['method'] ?? 'GET';
-        $this->timeout = $options['timeout'] ?? null;
+        if (isset($options['timeout']))
+        {
+            $this->timeout = (float) $options['timeout'];
+        }
         $this->options = $options;
     }
 

--- a/src/Components/hprose/src/Imi-Server-Hprose/Server.php
+++ b/src/Components/hprose/src/Imi-Server-Hprose/Server.php
@@ -30,7 +30,7 @@ class Server extends BaseRpcServer
     protected function createServer(): void
     {
         $config = $this->getServerInitConfig();
-        $this->swooleServer = new \Swoole\Server($config['host'], $config['port'], $config['mode'], $config['sockType']);
+        $this->swooleServer = new \Swoole\Server($config['host'], (int) $config['port'], (int) $config['mode'], (int) $config['sockType']);
         $this->hproseService = new \Hprose\Swoole\Socket\Service();
         $this->parseConfig($config);
     }
@@ -43,7 +43,7 @@ class Server extends BaseRpcServer
         $config = $this->getServerInitConfig();
         // @phpstan-ignore-next-line
         $this->swooleServer = ServerManager::getServer('main')->getSwooleServer();
-        $this->swoolePort = $this->swooleServer->addListener($config['host'], $config['port'], $config['sockType']);
+        $this->swoolePort = $this->swooleServer->addListener((int) $config['host'], (int) $config['port'], (int) $config['sockType']);
         $this->swoolePort->set([]);
         $this->hproseService = new \Hprose\Swoole\Socket\Service();
         $this->parseConfig($config);
@@ -90,9 +90,9 @@ class Server extends BaseRpcServer
     {
         return [
             'host'      => $this->config['host'] ?? '0.0.0.0',
-            'port'      => $this->config['port'] ?? 8080,
+            'port'      => (int) ($this->config['port'] ?? 8080),
             'sockType'  => isset($this->config['sockType']) ? (\SWOOLE_SOCK_TCP | $this->config['sockType']) : \SWOOLE_SOCK_TCP,
-            'mode'      => $this->config['mode'] ?? swoole_process,
+            'mode'      => (int) ($this->config['mode'] ?? \SWOOLE_BASE),
         ];
     }
 

--- a/src/Components/mqtt/src/Client/MQTTClient.php
+++ b/src/Components/mqtt/src/Client/MQTTClient.php
@@ -92,7 +92,7 @@ class MQTTClient
         {
             $will = null;
         }
-        $connection = (new Connection($config['host'], $config['port'], $config['timeout'] ?? null, $config['pingTimespan'] ?? null, $config['username'] ?? '', $config['password'] ?? '', $will, $config['clientId'] ?? '', $config['keepAlive'] ?? 60, $config['protocol'] ?? 4, $config['clean'] ?? true))
+        $connection = (new Connection($config['host'], (int) $config['port'], isset($config['timeout']) ? (float) ($config['timeout']) : null, isset($config['pingTimespan']) ? (float) ($config['pingTimespan']) : null, $config['username'] ?? '', $config['password'] ?? '', $will, $config['clientId'] ?? '', (int) ($config['keepAlive'] ?? 60), (int) ($config['protocol'] ?? 4), (bool) ($config['clean'] ?? true)))
             ->withSsl($config['ssl'] ?? false)
             ->withSslCertFile($config['sslCertFile'] ?? null)
             ->withSslKeyFile($config['sslKeyFile'] ?? null)

--- a/src/Components/swoole/src/Db/Driver/Swoole/Driver.php
+++ b/src/Components/swoole/src/Db/Driver/Swoole/Driver.php
@@ -109,7 +109,7 @@ class Driver extends MysqlBase
         $option = $this->option;
         $serverConfig = [
             'host'          => $option['host'] ?? '127.0.0.1',
-            'port'          => $option['port'] ?? 3306,
+            'port'          => (int) ($option['port'] ?? 3306),
             'user'          => $option['username'] ?? 'root',
             'password'      => $option['password'] ?? '',
             'database'      => $option['database'] ?? '',

--- a/src/Components/swoole/src/Server/Base.php
+++ b/src/Components/swoole/src/Server/Base.php
@@ -416,7 +416,7 @@ abstract class Base extends BaseServer implements ISwooleServer
         /** @var ISwooleServer $server */
         $server = ServerManager::getServer('main', ISwooleServer::class);
         $this->swooleServer = $server->getSwooleServer();
-        $port = $this->swooleServer->addListener($config['host'], $config['port'], $config['sockType']);
+        $port = $this->swooleServer->addListener($config['host'], (int) $config['port'], (int) $config['sockType']);
         if (false === $port)
         {
             throw new \RuntimeException(sprintf('Swoole addListener(%s, %s, %s) failed', $config['host'], $config['port'], $config['sockType']));

--- a/src/Components/swoole/src/Server/Http/Server.php
+++ b/src/Components/swoole/src/Server/Http/Server.php
@@ -56,8 +56,8 @@ class Server extends Base implements ISwooleHttpServer
     protected function createServer(): void
     {
         $config = $this->getServerInitConfig();
-        $this->swooleServer = new \Swoole\Http\Server($config['host'], $config['port'], $config['mode'], $config['sockType']);
-        $this->https = \defined('SWOOLE_SSL') && Bit::has($config['sockType'], \SWOOLE_SSL);
+        $this->swooleServer = new \Swoole\Http\Server($config['host'], (int) $config['port'], (int) $config['mode'], (int) $config['sockType']);
+        $this->https = \defined('SWOOLE_SSL') && Bit::has((int) $config['sockType'], \SWOOLE_SSL);
         $this->http2 = $this->config['configs']['open_http2_protocol'] ?? false;
     }
 
@@ -69,7 +69,7 @@ class Server extends Base implements ISwooleHttpServer
         parent::createSubServer();
         $thisConfig = &$this->config;
         $thisConfig['configs']['open_http_protocol'] ??= true;
-        $this->https = \defined('SWOOLE_SSL') && isset($thisConfig['sockType']) && Bit::has($thisConfig['sockType'], \SWOOLE_SSL);
+        $this->https = \defined('SWOOLE_SSL') && isset($thisConfig['sockType']) && Bit::has((int) $thisConfig['sockType'], \SWOOLE_SSL);
         $this->http2 = $thisConfig['configs']['open_http2_protocol'] ?? false;
     }
 
@@ -80,9 +80,9 @@ class Server extends Base implements ISwooleHttpServer
     {
         return [
             'host'       => $this->config['host'] ?? '0.0.0.0',
-            'port'       => $this->config['port'] ?? 80,
-            'sockType'   => $this->config['sockType'] ?? \SWOOLE_SOCK_TCP,
-            'mode'       => $this->config['mode'] ?? \SWOOLE_BASE,
+            'port'       => (int) ($this->config['port'] ?? 80),
+            'sockType'   => (int) ($this->config['sockType'] ?? \SWOOLE_SOCK_TCP),
+            'mode'       => (int) ($this->config['mode'] ?? \SWOOLE_BASE),
         ];
     }
 

--- a/src/Components/swoole/src/Server/TcpServer/Server.php
+++ b/src/Components/swoole/src/Server/TcpServer/Server.php
@@ -55,7 +55,7 @@ class Server extends Base implements ISwooleTcpServer
     protected function createServer(): void
     {
         $config = $this->getServerInitConfig();
-        $this->swooleServer = new \Swoole\Server($config['host'], $config['port'], $config['mode'], $config['sockType']);
+        $this->swooleServer = new \Swoole\Server($config['host'], (int) $config['port'], (int) $config['mode'], (int) $config['sockType']);
     }
 
     /**
@@ -78,9 +78,9 @@ class Server extends Base implements ISwooleTcpServer
     {
         return [
             'host'      => $this->config['host'] ?? '0.0.0.0',
-            'port'      => $this->config['port'] ?? 8080,
+            'port'      => (int) ($this->config['port'] ?? 8080),
             'sockType'  => isset($this->config['sockType']) ? (\SWOOLE_SOCK_TCP | $this->config['sockType']) : \SWOOLE_SOCK_TCP,
-            'mode'      => $this->config['mode'] ?? \SWOOLE_BASE,
+            'mode'      => (int) ($this->config['mode'] ?? \SWOOLE_BASE),
         ];
     }
 

--- a/src/Components/swoole/src/Server/UdpServer/Server.php
+++ b/src/Components/swoole/src/Server/UdpServer/Server.php
@@ -39,7 +39,7 @@ class Server extends Base implements ISwooleUdpServer
     protected function createServer(): void
     {
         $config = $this->getServerInitConfig();
-        $this->swooleServer = new \Swoole\Server($config['host'], $config['port'], $config['mode'], $config['sockType']);
+        $this->swooleServer = new \Swoole\Server($config['host'], (int) $config['port'], (int) $config['mode'], (int) $config['sockType']);
     }
 
     /**
@@ -62,9 +62,9 @@ class Server extends Base implements ISwooleUdpServer
     {
         return [
             'host'      => $this->config['host'] ?? '0.0.0.0',
-            'port'      => $this->config['port'] ?? 8080,
+            'port'      => (int) ($this->config['port'] ?? 8080),
             'sockType'  => isset($this->config['sockType']) ? (\SWOOLE_SOCK_UDP | $this->config['sockType']) : \SWOOLE_SOCK_UDP,
-            'mode'      => $this->config['mode'] ?? \SWOOLE_BASE,
+            'mode'      => (int) ($this->config['mode'] ?? \SWOOLE_BASE),
         ];
     }
 

--- a/src/Components/swoole/src/Server/WebSocket/Server.php
+++ b/src/Components/swoole/src/Server/WebSocket/Server.php
@@ -84,8 +84,8 @@ class Server extends Base implements ISwooleWebSocketServer
     protected function createServer(): void
     {
         $config = $this->getServerInitConfig();
-        $this->swooleServer = new \Swoole\WebSocket\Server($config['host'], $config['port'], $config['mode'], $config['sockType']);
-        $this->https = $this->wss = \defined('SWOOLE_SSL') && Bit::has($config['sockType'], \SWOOLE_SSL);
+        $this->swooleServer = new \Swoole\WebSocket\Server($config['host'], (int) $config['port'], (int) $config['mode'], (int) $config['sockType']);
+        $this->https = $this->wss = \defined('SWOOLE_SSL') && Bit::has((int) $config['sockType'], \SWOOLE_SSL);
         $this->http2 = $this->config['configs']['open_http2_protocol'] ?? false;
     }
 
@@ -107,9 +107,9 @@ class Server extends Base implements ISwooleWebSocketServer
     {
         return [
             'host'      => $this->config['host'] ?? '0.0.0.0',
-            'port'      => $this->config['port'] ?? 8080,
-            'sockType'  => $this->config['sockType'] ?? \SWOOLE_SOCK_TCP,
-            'mode'      => $this->config['mode'] ?? \SWOOLE_BASE,
+            'port'      => (int) ($this->config['port'] ?? 8080),
+            'sockType'  => (int) ($this->config['sockType'] ?? \SWOOLE_SOCK_TCP),
+            'mode'      => (int) ($this->config['mode'] ?? \SWOOLE_BASE),
         ];
     }
 

--- a/src/Components/workerman-gateway/src/Swoole/Server/Business/TcpBusinessServer.php
+++ b/src/Components/workerman-gateway/src/Swoole/Server/Business/TcpBusinessServer.php
@@ -40,9 +40,9 @@ if (\Imi\Util\Imi::checkAppType('swoole'))
         {
             return [
                 'host'      => $this->config['host'] ?? '127.0.0.1',
-                'port'      => $this->config['port'] ?? 0,
-                'sockType'  => $this->config['sockType'] ?? \SWOOLE_SOCK_TCP,
-                'mode'      => $this->config['mode'] ?? \SWOOLE_BASE,
+                'port'      => (int) ($this->config['port'] ?? 0),
+                'sockType'  => (int) ($this->config['sockType'] ?? \SWOOLE_SOCK_TCP),
+                'mode'      => (int) ($this->config['mode'] ?? \SWOOLE_BASE),
             ];
         }
 

--- a/src/Components/workerman-gateway/src/Swoole/Server/Business/WebSocketBusinessServer.php
+++ b/src/Components/workerman-gateway/src/Swoole/Server/Business/WebSocketBusinessServer.php
@@ -40,9 +40,9 @@ if (\Imi\Util\Imi::checkAppType('swoole'))
         {
             return [
                 'host'      => $this->config['host'] ?? '127.0.0.1',
-                'port'      => $this->config['port'] ?? 0,
-                'sockType'  => $this->config['sockType'] ?? \SWOOLE_SOCK_TCP,
-                'mode'      => $this->config['mode'] ?? \SWOOLE_BASE,
+                'port'      => (int) ($this->config['port'] ?? 0),
+                'sockType'  => (int) ($this->config['sockType'] ?? \SWOOLE_SOCK_TCP),
+                'mode'      => (int) ($this->config['mode'] ?? \SWOOLE_BASE),
             ];
         }
 

--- a/src/Components/workerman/src/Server/Channel/Server.php
+++ b/src/Components/workerman/src/Server/Channel/Server.php
@@ -29,7 +29,7 @@ class Server extends \Imi\Workerman\Server\Tcp\Server
         else
         {
             $ip = $config['host'] ?? '0.0.0.0';
-            $port = $config['port'] ?? 2206;
+            $port = (int) ($config['port'] ?? 2206);
         }
         $channelServer = $this->channelServer = new \Channel\Server($ip, $port);
         $refClass = new ReflectionClass($channelServer);

--- a/src/Db/Mysql/Drivers/Mysqli/Driver.php
+++ b/src/Db/Mysql/Drivers/Mysqli/Driver.php
@@ -111,7 +111,7 @@ class Driver extends MysqlBase
     public function open(): bool
     {
         $option = $this->option;
-        $this->instance = $instance = new \mysqli($option['host'] ?? '127.0.0.1', $option['username'], $option['password'], $option['database'], $option['port'] ?? 3306);
+        $this->instance = $instance = new \mysqli($option['host'] ?? '127.0.0.1', $option['username'], $option['password'], $option['database'], (int) ($option['port'] ?? 3306));
         $instance->set_charset($option['charset'] ?? 'utf8');
         $this->execInitSqls();
 

--- a/src/Redis/RedisHandler.php
+++ b/src/Redis/RedisHandler.php
@@ -343,7 +343,7 @@ class RedisHandler
             }
             else
             {
-                $result = $redis->connect($this->host, (int)$this->port, $this->timeout);
+                $result = $redis->connect($this->host, $this->port, $this->timeout);
             }
             if ($result)
             {

--- a/src/Redis/RedisHandler.php
+++ b/src/Redis/RedisHandler.php
@@ -343,7 +343,7 @@ class RedisHandler
             }
             else
             {
-                $result = $redis->connect($this->host, $this->port, $this->timeout);
+                $result = $redis->connect($this->host, (int)$this->port, $this->timeout);
             }
             if ($result)
             {

--- a/src/Redis/RedisManager.php
+++ b/src/Redis/RedisManager.php
@@ -196,7 +196,7 @@ class RedisManager
             {
                 throw new \RedisException($redis->getLastError());
             }
-            if (isset($config['db']) && !$redis->select($config['db']))
+            if (isset($config['db']) && !$redis->select((int) $config['db']))
             {
                 throw new \RedisException($redis->getLastError());
             }

--- a/src/Redis/RedisManager.php
+++ b/src/Redis/RedisManager.php
@@ -190,7 +190,7 @@ class RedisManager
             }
             else
             {
-                $redis->connect($host, (int)$config['port'] ?? 6379, $config['timeout'] ?? 0);
+                $redis->connect($host, (int) ($config['port'] ?? 6379), (float) ($config['timeout'] ?? 0));
             }
             if (('' !== ($config['password'] ?? '')) && !$redis->auth($config['password']))
             {

--- a/src/Redis/RedisManager.php
+++ b/src/Redis/RedisManager.php
@@ -190,7 +190,7 @@ class RedisManager
             }
             else
             {
-                $redis->connect($host, $config['port'] ?? 6379, $config['timeout'] ?? 0);
+                $redis->connect($host, (int)$config['port'] ?? 6379, $config['timeout'] ?? 0);
             }
             if (('' !== ($config['password'] ?? '')) && !$redis->auth($config['password']))
             {

--- a/src/Redis/Traits/TRedisPool.php
+++ b/src/Redis/Traits/TRedisPool.php
@@ -43,7 +43,7 @@ trait TRedisPool
                     {
                         [$host, $port] = explode(':', $node);
                     }
-                    $redisSentinel = new \RedisSentinel($host, $port, (float) ($config['timeout'] ?? 0), (bool) ($config['persistent'] ?? false), (int) ($config['retryInterval'] ?? 0), (float) ($config['readTimeout'] ?? 0));
+                    $redisSentinel = new \RedisSentinel($host, $port, (float) ($config['timeout'] ?? 0), $config['persistent'] ?? false, (int) ($config['retryInterval'] ?? 0), (float) ($config['readTimeout'] ?? 0));
                     $masterArray = $redisSentinel->master($master);
                     if (\is_array($masterArray) && isset($masterArray['ip'], $masterArray['port']))
                     {

--- a/src/Redis/Traits/TRedisPool.php
+++ b/src/Redis/Traits/TRedisPool.php
@@ -43,7 +43,7 @@ trait TRedisPool
                     {
                         [$host, $port] = explode(':', $node);
                     }
-                    $redisSentinel = new \RedisSentinel($host, $port, $config['timeout'] ?? 0, $config['persistent'] ?? false, $config['retryInterval'] ?? 0, $config['readTimeout'] ?? 0);
+                    $redisSentinel = new \RedisSentinel($host, $port, (float) ($config['timeout'] ?? 0), (bool) ($config['persistent'] ?? false), (int) ($config['retryInterval'] ?? 0), (float) ($config['readTimeout'] ?? 0));
                     $masterArray = $redisSentinel->master($master);
                     if (\is_array($masterArray) && isset($masterArray['ip'], $masterArray['port']))
                     {


### PR DESCRIPTION
redis->connect添加对port参数int转换，修复在env中通过@app.pools.redis.resource.port = 6379 添加redis端口号配置导致的报错【imi.ERROR: TypeError: Redis::connect(): Argument #2 ($port) must be of type int, string given in /var/www/juxingbole-douyin-user-crawler/vendor/imiphp/imi/src/Redis/RedisHandler.php:297】