### PR TITLE
增强查询构建器的一些方法支持传参数绑定

### DIFF
--- a/doc/base/version/2.0-2.1.md
+++ b/doc/base/version/2.0-2.1.md
@@ -22,7 +22,7 @@ v2.0 是一个非常成功的 LTS 版本，进行了底层重构，增加了强�
 
 **发布日期：** ``
 
-* 查询构建器 `joinRaw()` 支持传参数绑定
+* 查询构建器 `fieldRaw()`、`joinRaw()`、`whereRaw()`、`orWhereRaw()`、`groupRaw()`、`havingRaw()`、`orderRaw()` 支持传参数绑定
 
 ### v2.1.40
 

--- a/doc/base/version/2.0-2.1.md
+++ b/doc/base/version/2.0-2.1.md
@@ -18,9 +18,15 @@ v2.0 是一个非常成功的 LTS 版本，进行了底层重构，增加了强�
 
 ## 新功能
 
+### v2.1.41
+
+**发布日期：** ``
+
+* 查询构建器 `joinRaw()` 支持传参数绑定
+
 ### v2.1.40
 
-**发布日期：** `2023-03-17`
+**发布日期：** `2023-03-24`
 
 * 支持 Phar 构建前后回调配置 ([#478](https://github.com/imiphp/imi/pull/478)) ([文档](https://doc.imiphp.com/v2.1/components/phar/index.html))
 

--- a/doc/base/version/2.0-2.1.md
+++ b/doc/base/version/2.0-2.1.md
@@ -22,7 +22,7 @@ v2.0 是一个非常成功的 LTS 版本，进行了底层重构，增加了强�
 
 **发布日期：** ``
 
-* 查询构建器 `fieldRaw()`、`joinRaw()`、`whereRaw()`、`orWhereRaw()`、`groupRaw()`、`havingRaw()`、`orderRaw()` 支持传参数绑定
+* 查询构建器 `fieldRaw()`、`joinRaw()`、`whereRaw()`、`orWhereRaw()`、`groupRaw()`、`havingRaw()`、`orderRaw()`、`setFieldExp()`、`setFieldInc()`、`setFieldDec()` 支持传参数绑定
 
 ### v2.1.40
 

--- a/doc/components/db/index.md
+++ b/doc/components/db/index.md
@@ -376,6 +376,9 @@ Db::query()->field(['id', 'name1 name', 'age1 as age']);
 
 // 传入参数原样代入到SQL中
 Db::query()->fieldRaw('id, name1 name, age1 as age');
+
+// 传入参数原样代入到SQL中，也支持参数绑定
+Db::query()->fieldRaw('id, name1 name, age1 as age, ? as value', null, [123]);
 ```
 
 ### 条件 where
@@ -437,6 +440,11 @@ Db::query()->whereRaw('id >= 1');
 // 传入参数原样代入到SQL中，并且为or条件
 Db::query()->whereRaw('id >= 1', 'or');
 Db::query()->orWhereRaw('id >= 1');
+
+// 支持参数绑定
+// 传入参数原样代入到SQL中，并且为or条件
+Db::query()->whereRaw('id >= ?', 'or', [1]);
+Db::query()->orWhereRaw('id >= ?', [1]);
 ```
 
 #### whereBrackets
@@ -545,6 +553,9 @@ Db::query()->order('id')->order('age', 'desc');
 // order by id desc
 Db::query()->orderRaw('id desc');
 
+// order by id desc, 1 asc
+Db::query()->orderRaw('id desc, ? asc', [1]);
+
 // JSON 类型参数排序
 Db::query()->order('field1->uid', 'desc');
 ```
@@ -557,6 +568,9 @@ Db::query()->group('id', 'name');
 
 // group by sum(id)
 Db::query()->groupRaw('sum(id)');
+
+// group by sum(id), ?
+Db::query()->groupRaw('sum(id), ?', 123);
 ```
 
 ### having

--- a/doc/components/db/index.md
+++ b/doc/components/db/index.md
@@ -523,6 +523,10 @@ Db::query()->table('tb_test1')->join('tb_test2', 'tb_test1.aid', '=', 'tb_test2.
 // select * from tb_test1 left join tb_test2 on tb_test1.aid = tb_test2.bid
 Db::query()->table('tb_test1')->joinRaw('left join tb_test2 on tb_test1.aid = tb_test2.bid');
 
+// 支持参数绑定
+// select * from tb_test1 left join tb_test2 on tb_test1.aid = tb_test2.bid and tb_test2.xxx = ?
+Db::query()->table('tb_test1')->joinRaw('left join tb_test2 on tb_test1.aid = tb_test2.bid and tb_test2.xxx = ?', [123]);
+
 // 下面三种用法，第5个参数都支持传Where
 // left join
 Db::query()->table('tb_test1')->leftJoin('tb_test2', 'tb_test1.aid', '=', 'tb_test2.bid');

--- a/doc/components/db/index.md
+++ b/doc/components/db/index.md
@@ -1023,7 +1023,7 @@ $result = Db::query()->table('tb_test')
 // update tb_test set score = score + 1 where id = 1
 $result = Db::query()->table('tb_test')
                      ->where('id', '=', 1)
-                     ->setFieldExp('score', 'score + 1')
+                     ->setFieldExp('score', 'score + ?', [1])
                      ->update();
 ```
 

--- a/src/Components/pgsql/src/Db/Query/Builder/BaseBuilder.php
+++ b/src/Components/pgsql/src/Db/Query/Builder/BaseBuilder.php
@@ -19,6 +19,7 @@ abstract class BaseBuilder extends \Imi\Db\Query\Builder\BaseBuilder
         }
         $result = [];
         $query = $this->query;
+        $params = &$this->params;
         foreach ($fields as $k => $v)
         {
             if (is_numeric($k))
@@ -38,6 +39,11 @@ abstract class BaseBuilder extends \Imi\Db\Query\Builder\BaseBuilder
                 $field = new Field(null, null, $k, $v);
             }
             $result[] = $field->toString($query);
+            $binds = $field->getBinds();
+            if ($binds)
+            {
+                $params = array_merge($params, $binds);
+            }
         }
 
         return implode(',', $result);

--- a/src/Components/pgsql/src/Db/Query/Builder/InsertBuilder.php
+++ b/src/Components/pgsql/src/Db/Query/Builder/InsertBuilder.php
@@ -39,6 +39,11 @@ class InsertBuilder extends BaseBuilder
                         $fields[] = $query->fieldQuote($k);
                         $valueParams[] = $v->toString($query);
                     }
+                    $binds = $v->getBinds();
+                    if ($binds)
+                    {
+                        $params = array_merge($params, $binds);
+                    }
                 }
                 else
                 {

--- a/src/Components/pgsql/src/Db/Query/Builder/ReplaceBuilder.php
+++ b/src/Components/pgsql/src/Db/Query/Builder/ReplaceBuilder.php
@@ -43,6 +43,11 @@ class ReplaceBuilder extends BaseBuilder
                     {
                         $setStrs[] = $query->fieldQuote($k) . ' = ' . $v->toString($query);
                     }
+                    $binds = $v->getBinds();
+                    if ($binds)
+                    {
+                        $params = array_merge($params, $binds);
+                    }
                 }
                 else
                 {

--- a/src/Components/pgsql/src/Db/Query/Builder/UpdateBuilder.php
+++ b/src/Components/pgsql/src/Db/Query/Builder/UpdateBuilder.php
@@ -51,6 +51,11 @@ class UpdateBuilder extends BaseBuilder
                         $setStrs[] = $field . ' = ' . $v->toString($query);
                     }
                 }
+                $binds = $v->getBinds();
+                if ($binds)
+                {
+                    $params = array_merge($params, $binds);
+                }
             }
             else
             {

--- a/src/Components/pgsql/tests/Unit/Db/QueryCurdBaseTest.php
+++ b/src/Components/pgsql/tests/Unit/Db/QueryCurdBaseTest.php
@@ -331,4 +331,19 @@ abstract class QueryCurdBaseTest extends TestCase
             'json_data' => '{"a": "1", "uid": "' . $uid . '", "name": "bbb", "list1": [{"id": "2"}], "list2": [1, 2, 3]}',
         ], $result->get());
     }
+
+    public function testRawBinds(): void
+    {
+        $query = Db::query()->from('test')
+                            ->fieldRaw('test.*, ?', null, ['imi'])
+                            ->joinRaw('join test2 on test.id = test2.id and test2.id2 = ?', [1])
+                            ->whereRaw('test.id = ?', 'and', [2])
+                            ->orWhereRaw('test.id = ?', [3])
+                            ->groupRaw('test.id, ?', [4])
+                            ->havingRaw('test.id = ?', 'and', [5])
+                            ->orderRaw('field(test.id, ?, ?)', [6, 7])
+        ;
+        $this->assertEquals('select test.*, ? from "test" join test2 on test.id = test2.id and test2.id2 = ? where test.id = ? or test.id = ? group by test.id, ? having test.id = ? order by field(test.id, ?, ?)', $query->buildSelectSql());
+        $this->assertEquals(['imi', 1, 2, 3, 4, 5, 6, 7], $query->getBinds());
+    }
 }

--- a/src/Components/pgsql/tests/Unit/Db/QueryCurdBaseTest.php
+++ b/src/Components/pgsql/tests/Unit/Db/QueryCurdBaseTest.php
@@ -346,4 +346,26 @@ abstract class QueryCurdBaseTest extends TestCase
         $this->assertEquals('select test.*, ? from "test" join test2 on test.id = test2.id and test2.id2 = ? where test.id = ? or test.id = ? group by test.id, ? having test.id = ? order by field(test.id, ?, ?)', $query->buildSelectSql());
         $this->assertEquals(['imi', 1, 2, 3, 4, 5, 6, 7], $query->getBinds());
     }
+
+    public function testSetFieldExp(): void
+    {
+        $query = Db::query()->from('test')->setFieldExp('c', '1 + ?', [1])
+        ;
+        $this->assertEquals('insert into "test"("c") values(1 + ?)', $query->buildInsertSql());
+        $this->assertEquals([1], $query->getBinds());
+
+        $query = Db::query()->from('test')->setFieldInc('a', 1)
+                                          ->setFieldDec('b', 2)
+                                          ->setFieldExp('c', 'c + ?', [3])
+        ;
+        $this->assertEquals('update "test" set "a" = "a" + ?,"b" = "b" - ?,"c" = c + ?', $query->buildUpdateSql());
+        $this->assertEquals([1, 2, 3], $query->getBinds());
+
+        $query = Db::query()->from('test')->setFieldInc('a', 4)
+                                          ->setFieldDec('b', 5)
+                                          ->setFieldExp('c', 'c + ?', [6])
+        ;
+        $this->assertEquals('replace into "test" set "a" = "a" + ?,"b" = "b" - ?,"c" = c + ?', $query->buildReplaceSql());
+        $this->assertEquals([4, 5, 6], $query->getBinds());
+    }
 }

--- a/src/Db/Mysql/Query/Builder/BaseBuilder.php
+++ b/src/Db/Mysql/Query/Builder/BaseBuilder.php
@@ -19,6 +19,7 @@ abstract class BaseBuilder extends \Imi\Db\Query\Builder\BaseBuilder
         }
         $result = [];
         $query = $this->query;
+        $params = &$this->params;
         foreach ($fields as $k => $v)
         {
             if (is_numeric($k))
@@ -38,6 +39,11 @@ abstract class BaseBuilder extends \Imi\Db\Query\Builder\BaseBuilder
                 $field = new Field(null, null, $k, $v);
             }
             $result[] = $field->toString($query);
+            $binds = $field->getBinds();
+            if ($binds)
+            {
+                $params = array_merge($params, $binds);
+            }
         }
 
         return implode(',', $result);

--- a/src/Db/Mysql/Query/Builder/InsertBuilder.php
+++ b/src/Db/Mysql/Query/Builder/InsertBuilder.php
@@ -40,6 +40,11 @@ class InsertBuilder extends BaseBuilder
                         $fields[] = $query->fieldQuote($k);
                         $valueParams[] = $v->toString($query);
                     }
+                    $binds = $v->getBinds();
+                    if ($binds)
+                    {
+                        $params = array_merge($params, $binds);
+                    }
                 }
                 else
                 {

--- a/src/Db/Mysql/Query/Builder/ReplaceBuilder.php
+++ b/src/Db/Mysql/Query/Builder/ReplaceBuilder.php
@@ -43,6 +43,11 @@ class ReplaceBuilder extends BaseBuilder
                     {
                         $setStrs[] = $query->fieldQuote($k) . ' = ' . $v->toString($query);
                     }
+                    $binds = $v->getBinds();
+                    if ($binds)
+                    {
+                        $params = array_merge($params, $binds);
+                    }
                 }
                 else
                 {

--- a/src/Db/Mysql/Query/Builder/UpdateBuilder.php
+++ b/src/Db/Mysql/Query/Builder/UpdateBuilder.php
@@ -48,6 +48,11 @@ class UpdateBuilder extends BaseBuilder
                         $setStrs[] = $field . ' = ' . $v->toString($query);
                     }
                 }
+                $binds = $v->getBinds();
+                if ($binds)
+                {
+                    $params = array_merge($params, $binds);
+                }
             }
             else
             {

--- a/src/Db/Query/Builder/BaseBuilder.php
+++ b/src/Db/Query/Builder/BaseBuilder.php
@@ -199,9 +199,15 @@ abstract class BaseBuilder implements IBuilder
         {
             $groups = [];
             $query = $this->query;
+            $params = &$this->params;
             foreach ($group as $tmpGroup)
             {
                 $groups[] = $tmpGroup->toString($query);
+                $binds = $tmpGroup->getBinds();
+                if ($binds)
+                {
+                    $params = array_merge($params, $binds);
+                }
             }
 
             return ' group by ' . implode(',', $groups);
@@ -225,6 +231,7 @@ abstract class BaseBuilder implements IBuilder
         }
         $params = &$this->params;
         $query = $this->query;
+        $params = &$this->params;
         $result = [];
         foreach ($having as $item)
         {

--- a/src/Db/Query/Database.php
+++ b/src/Db/Query/Database.php
@@ -98,12 +98,4 @@ class Database implements IDatabase
             $this->database,
         ], $this->alias);
     }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function getBinds(): array
-    {
-        return [];
-    }
 }

--- a/src/Db/Query/Interfaces/IBase.php
+++ b/src/Db/Query/Interfaces/IBase.php
@@ -19,7 +19,7 @@ interface IBase
     /**
      * 设置原生语句.
      */
-    public function setRawSQL(string $rawSQL): void;
+    public function setRawSQL(string $rawSQL, array $binds = []): void;
 
     public function toString(IQuery $query): string;
 

--- a/src/Db/Query/Interfaces/IQuery.php
+++ b/src/Db/Query/Interfaces/IQuery.php
@@ -314,7 +314,7 @@ interface IQuery
      *
      * @return static
      */
-    public function joinRaw(string $raw): self;
+    public function joinRaw(string $raw, array $binds = []): self;
 
     /**
      * left join.

--- a/src/Db/Query/Interfaces/IQuery.php
+++ b/src/Db/Query/Interfaces/IQuery.php
@@ -110,7 +110,7 @@ interface IQuery
      *
      * @return static
      */
-    public function fieldRaw(string $raw, ?string $alias = null): self;
+    public function fieldRaw(string $raw, ?string $alias = null, array $binds = []): self;
 
     /**
      * 设置 where 条件，一般用于 =、>、<、like等.
@@ -126,7 +126,7 @@ interface IQuery
      *
      * @return static
      */
-    public function whereRaw(string $raw, string $logicalOperator = 'and'): self;
+    public function whereRaw(string $raw, string $logicalOperator = 'and', array $binds = []): self;
 
     /**
      * 设置 where 条件，传入回调，回调中的条件加括号.
@@ -215,7 +215,7 @@ interface IQuery
      *
      * @return static
      */
-    public function orWhereRaw(string $where): self;
+    public function orWhereRaw(string $where, array $binds = []): self;
 
     /**
      * 设置 where or 条件，传入回调，回调中的条件加括号.
@@ -375,7 +375,7 @@ interface IQuery
      *
      * @return static
      */
-    public function orderRaw($raw): self;
+    public function orderRaw($raw, array $binds = []): self;
 
     /**
      * 设置分页
@@ -411,7 +411,7 @@ interface IQuery
      *
      * @return static
      */
-    public function groupRaw(string $raw): self;
+    public function groupRaw(string $raw, array $binds = []): self;
 
     /**
      * 设置 having 条件.
@@ -427,7 +427,7 @@ interface IQuery
      *
      * @return static
      */
-    public function havingRaw(string $raw, string $logicalOperator = 'and'): self;
+    public function havingRaw(string $raw, string $logicalOperator = 'and', array $binds = []): self;
 
     /**
      * 设置 having 条件，传入回调，回调中的条件加括号.

--- a/src/Db/Query/Interfaces/IQuery.php
+++ b/src/Db/Query/Interfaces/IQuery.php
@@ -666,7 +666,7 @@ interface IQuery
      *
      * @return static
      */
-    public function setFieldExp(string $fieldName, string $exp): self;
+    public function setFieldExp(string $fieldName, string $exp, array $binds = []): self;
 
     /**
      * 设置递增字段.

--- a/src/Db/Query/Join.php
+++ b/src/Db/Query/Join.php
@@ -43,12 +43,7 @@ class Join implements IJoin
      */
     protected string $type = 'inner';
 
-    /**
-     * 绑定的数据们.
-     */
-    protected array $binds = [];
-
-    public function __construct(IQuery $query, ?string $table = null, ?string $left = null, ?string $operation = null, ?string $right = null, ?string $tableAlias = null, ?IBaseWhere $where = null, string $type = 'inner', array $binds = [])
+    public function __construct(IQuery $query, ?string $table = null, ?string $left = null, ?string $operation = null, ?string $right = null, ?string $tableAlias = null, ?IBaseWhere $where = null, string $type = 'inner')
     {
         $this->table = $thisTable = new Table();
         if (null !== $table)
@@ -64,7 +59,6 @@ class Join implements IJoin
         $this->right = $right;
         $this->where = $where;
         $this->type = $type;
-        $this->binds = $binds;
     }
 
     /**

--- a/src/Db/Query/Join.php
+++ b/src/Db/Query/Join.php
@@ -43,7 +43,12 @@ class Join implements IJoin
      */
     protected string $type = 'inner';
 
-    public function __construct(IQuery $query, ?string $table = null, ?string $left = null, ?string $operation = null, ?string $right = null, ?string $tableAlias = null, ?IBaseWhere $where = null, string $type = 'inner')
+    /**
+     * 绑定的数据们.
+     */
+    protected array $binds = [];
+
+    public function __construct(IQuery $query, ?string $table = null, ?string $left = null, ?string $operation = null, ?string $right = null, ?string $tableAlias = null, ?IBaseWhere $where = null, string $type = 'inner', array $binds = [])
     {
         $this->table = $thisTable = new Table();
         if (null !== $table)
@@ -59,6 +64,7 @@ class Join implements IJoin
         $this->right = $right;
         $this->where = $where;
         $this->type = $type;
+        $this->binds = $binds;
     }
 
     /**
@@ -203,7 +209,7 @@ class Join implements IJoin
         }
         else
         {
-            return [];
+            return $this->binds;
         }
     }
 }

--- a/src/Db/Query/Order.php
+++ b/src/Db/Query/Order.php
@@ -72,12 +72,4 @@ class Order implements IOrder
 
         return $query->fieldQuote($this->fieldName) . ' ' . $this->direction;
     }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function getBinds(): array
-    {
-        return [];
-    }
 }

--- a/src/Db/Query/Partition.php
+++ b/src/Db/Query/Partition.php
@@ -37,12 +37,4 @@ class Partition implements IPartition
 
         return '';
     }
-
-    /**
-     * 获取绑定的数据们.
-     */
-    public function getBinds(): array
-    {
-        return [];
-    }
 }

--- a/src/Db/Query/Query.php
+++ b/src/Db/Query/Query.php
@@ -295,11 +295,11 @@ abstract class Query implements IQuery
     /**
      * {@inheritDoc}
      */
-    public function fieldRaw(string $raw, ?string $alias = null): self
+    public function fieldRaw(string $raw, ?string $alias = null, array $binds = []): self
     {
         $field = new Field();
         $field->useRaw();
-        $field->setRawSQL($raw);
+        $field->setRawSQL($raw, $binds);
         if (null !== $alias)
         {
             $field->setAlias($alias);
@@ -322,11 +322,11 @@ abstract class Query implements IQuery
     /**
      * {@inheritDoc}
      */
-    public function whereRaw(string $raw, string $logicalOperator = LogicalOperator::AND): self
+    public function whereRaw(string $raw, string $logicalOperator = LogicalOperator::AND, array $binds = []): self
     {
         $where = new Where();
         $where->useRaw();
-        $where->setRawSQL($raw);
+        $where->setRawSQL($raw, $binds);
         $where->setLogicalOperator($logicalOperator);
         $this->option->where[] = $where;
 
@@ -470,9 +470,9 @@ abstract class Query implements IQuery
     /**
      * {@inheritDoc}
      */
-    public function orWhereRaw(string $where): self
+    public function orWhereRaw(string $where, array $binds = []): self
     {
-        return $this->whereRaw($where, LogicalOperator::OR);
+        return $this->whereRaw($where, LogicalOperator::OR, $binds);
     }
 
     /**
@@ -578,9 +578,9 @@ abstract class Query implements IQuery
      */
     public function joinRaw(string $raw, array $binds = []): self
     {
-        $join = new Join($this, null, null, null, null, null, null, 'inner', $binds);
+        $join = new Join($this);
         $join->useRaw();
-        $join->setRawSQL($raw);
+        $join->setRawSQL($raw, $binds);
         $this->option->join[] = $join;
 
         return $this;
@@ -623,7 +623,7 @@ abstract class Query implements IQuery
     /**
      * {@inheritDoc}
      */
-    public function orderRaw($raw): self
+    public function orderRaw($raw, array $binds = []): self
     {
         $optionOrder = &$this->option->order;
         if (\is_array($raw))
@@ -647,7 +647,7 @@ abstract class Query implements IQuery
         {
             $order = new Order();
             $order->useRaw();
-            $order->setRawSQL($raw);
+            $order->setRawSQL($raw, $binds);
             $optionOrder[] = $order;
         }
 
@@ -706,11 +706,11 @@ abstract class Query implements IQuery
     /**
      * {@inheritDoc}
      */
-    public function groupRaw(string $raw): self
+    public function groupRaw(string $raw, array $binds = []): self
     {
         $group = new Group();
         $group->useRaw();
-        $group->setRawSQL($raw);
+        $group->setRawSQL($raw, $binds);
         $this->option->group[] = $group;
 
         return $this;
@@ -729,11 +729,11 @@ abstract class Query implements IQuery
     /**
      * {@inheritDoc}
      */
-    public function havingRaw(string $raw, string $logicalOperator = LogicalOperator::AND): self
+    public function havingRaw(string $raw, string $logicalOperator = LogicalOperator::AND, array $binds = []): self
     {
         $having = new Having();
         $having->useRaw();
-        $having->setRawSQL($raw);
+        $having->setRawSQL($raw, $binds);
         $having->setLogicalOperator($logicalOperator);
         $this->option->having[] = $having;
 

--- a/src/Db/Query/Query.php
+++ b/src/Db/Query/Query.php
@@ -576,9 +576,9 @@ abstract class Query implements IQuery
     /**
      * {@inheritDoc}
      */
-    public function joinRaw(string $raw): self
+    public function joinRaw(string $raw, array $binds = []): self
     {
-        $join = new Join($this);
+        $join = new Join($this, null, null, null, null, null, null, 'inner', $binds);
         $join->useRaw();
         $join->setRawSQL($raw);
         $this->option->join[] = $join;

--- a/src/Db/Query/Query.php
+++ b/src/Db/Query/Query.php
@@ -946,9 +946,9 @@ abstract class Query implements IQuery
     /**
      * {@inheritDoc}
      */
-    public function setFieldExp(string $fieldName, string $exp): self
+    public function setFieldExp(string $fieldName, string $exp, array $binds = []): self
     {
-        $this->option->saveData[$fieldName] = new Raw($exp);
+        $this->option->saveData[$fieldName] = new Raw($exp, $binds);
 
         return $this;
     }
@@ -958,9 +958,7 @@ abstract class Query implements IQuery
      */
     public function setFieldInc(string $fieldName, float $incValue = 1): self
     {
-        $this->option->saveData[$fieldName] = new Raw($this->fieldQuote($fieldName) . ' + ' . $incValue);
-
-        return $this;
+        return $this->setFieldExp($fieldName, $this->fieldQuote($fieldName) . ' + ?', [$incValue]);
     }
 
     /**
@@ -968,9 +966,7 @@ abstract class Query implements IQuery
      */
     public function setFieldDec(string $fieldName, float $decValue = 1): self
     {
-        $this->option->saveData[$fieldName] = new Raw($this->fieldQuote($fieldName) . ' - ' . $decValue);
-
-        return $this;
+        return $this->setFieldExp($fieldName, $this->fieldQuote($fieldName) . ' - ?', [$decValue]);
     }
 
     /**

--- a/src/Db/Query/Raw.php
+++ b/src/Db/Query/Raw.php
@@ -12,9 +12,9 @@ class Raw implements IBase
 {
     use TRaw;
 
-    public function __construct(string $raw)
+    public function __construct(string $raw, array $binds = [])
     {
-        $this->setRawSQL($raw);
+        $this->setRawSQL($raw, $binds);
     }
 
     /**
@@ -23,13 +23,5 @@ class Raw implements IBase
     public function toString(IQuery $query): string
     {
         return $this->rawSQL;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function getBinds(): array
-    {
-        return [];
     }
 }

--- a/src/Db/Query/Table.php
+++ b/src/Db/Query/Table.php
@@ -150,12 +150,4 @@ class Table implements ITable
             $this->prefix . $this->table,
         ], $this->alias);
     }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function getBinds(): array
-    {
-        return [];
-    }
 }

--- a/src/Db/Query/Traits/TRaw.php
+++ b/src/Db/Query/Traits/TRaw.php
@@ -17,6 +17,11 @@ trait TRaw
     protected string $rawSQL = '';
 
     /**
+     * 绑定的数据们.
+     */
+    protected array $binds = [];
+
+    /**
      * 获取是否使用原生语句.
      */
     public function isRaw(): bool
@@ -35,8 +40,17 @@ trait TRaw
     /**
      * 设置原生语句.
      */
-    public function setRawSQL(string $rawSQL): void
+    public function setRawSQL(string $rawSQL, array $binds = []): void
     {
         $this->rawSQL = $rawSQL;
+        $this->binds = $binds;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getBinds(): array
+    {
+        return $this->binds;
     }
 }

--- a/src/Db/Query/Where/Where.php
+++ b/src/Db/Query/Where/Where.php
@@ -32,11 +32,6 @@ class Where extends BaseWhere implements IWhere
     protected $value;
 
     /**
-     * 绑定的数据们.
-     */
-    protected array $binds = [];
-
-    /**
      * @param mixed $value
      */
     public function __construct(?string $fieldName = null, ?string $operation = null, $value = null, string $logicalOperator = LogicalOperator::AND)
@@ -47,11 +42,11 @@ class Where extends BaseWhere implements IWhere
         $this->logicalOperator = $logicalOperator;
     }
 
-    public static function raw(string $rawSql, string $logicalOperator = LogicalOperator::AND): self
+    public static function raw(string $rawSql, string $logicalOperator = LogicalOperator::AND, array $binds = []): self
     {
         $where = new self();
         $where->useRaw(true);
-        $where->setRawSQL($rawSql);
+        $where->setRawSQL($rawSql, $binds);
         $where->setLogicalOperator($logicalOperator);
 
         return $where;
@@ -126,13 +121,13 @@ class Where extends BaseWhere implements IWhere
      */
     public function toStringWithoutLogic(IQuery $query): string
     {
-        $binds = &$this->binds;
-        $binds = [];
-        $thisValues = &$this->value;
         if ($this->isRaw)
         {
             return $this->rawSQL;
         }
+        $binds = &$this->binds;
+        $binds = [];
+        $thisValues = &$this->value;
         $operation = $this->operation;
         $result = $query->fieldQuote($this->fieldName) . ' ' . $operation . ' ';
         switch (strtolower($operation))
@@ -193,13 +188,5 @@ class Where extends BaseWhere implements IWhere
         }
 
         return $result;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function getBinds(): array
-    {
-        return $this->binds;
     }
 }

--- a/src/Db/Query/Where/WhereBrackets.php
+++ b/src/Db/Query/Where/WhereBrackets.php
@@ -21,11 +21,6 @@ class WhereBrackets extends BaseWhere implements IWhereBrackets
      */
     protected $callback;
 
-    /**
-     * 绑定的数据们.
-     */
-    protected array $binds = [];
-
     public function __construct(callable $callback = null, string $logicalOperator = LogicalOperator::AND)
     {
         $this->callback = $callback;
@@ -116,13 +111,5 @@ class WhereBrackets extends BaseWhere implements IWhereBrackets
         {
             return (string) $callResult;
         }
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function getBinds(): array
-    {
-        return $this->binds;
     }
 }

--- a/tests/unit/Component/Tests/Db/QueryCurdBaseTest.php
+++ b/tests/unit/Component/Tests/Db/QueryCurdBaseTest.php
@@ -458,4 +458,11 @@ abstract class QueryCurdBaseTest extends BaseTest
         $this->assertEquals('insert ignore into `test` PARTITION(`a`,`b`) (`value`) values(:value)', $query->buildInsertSql(['value' => 123]));
         $this->assertEquals('insert ignore into `test` PARTITION(`a`,`b`) (`value`) values (:p1),(:p2)', $query->buildBatchInsertSql([['value' => 123], ['value' => 456]]));
     }
+
+    public function testJoin(): void
+    {
+        $query = Db::query()->from('test')->joinRaw('join test2 on test.id = test2.id and test2.id2 = ?', [123]);
+        $this->assertEquals('select * from `test` join test2 on test.id = test2.id and test2.id2 = ?', $query->buildSelectSql());
+        $this->assertEquals([123], $query->getBinds());
+    }
 }

--- a/tests/unit/Component/Tests/Db/QueryCurdBaseTest.php
+++ b/tests/unit/Component/Tests/Db/QueryCurdBaseTest.php
@@ -473,4 +473,26 @@ abstract class QueryCurdBaseTest extends BaseTest
         $this->assertEquals('select test.*, ? from `test` join test2 on test.id = test2.id and test2.id2 = ? where test.id = ? or test.id = ? group by test.id, ? having test.id = ? order by field(test.id, ?, ?)', $query->buildSelectSql());
         $this->assertEquals(['imi', 1, 2, 3, 4, 5, 6, 7], $query->getBinds());
     }
+
+    public function testSetFieldExp(): void
+    {
+        $query = Db::query()->from('test')->setFieldExp('c', '1 + ?', [1])
+        ;
+        $this->assertEquals('insert into `test` (`c`) values(1 + ?)', $query->buildInsertSql());
+        $this->assertEquals([1], $query->getBinds());
+
+        $query = Db::query()->from('test')->setFieldInc('a', 1)
+                                          ->setFieldDec('b', 2)
+                                          ->setFieldExp('c', 'c + ?', [3])
+        ;
+        $this->assertEquals('update `test` set `a` = `a` + ?,`b` = `b` - ?,`c` = c + ?', $query->buildUpdateSql());
+        $this->assertEquals([1, 2, 3], $query->getBinds());
+
+        $query = Db::query()->from('test')->setFieldInc('a', 4)
+                                          ->setFieldDec('b', 5)
+                                          ->setFieldExp('c', 'c + ?', [6])
+        ;
+        $this->assertEquals('replace into `test` set `a` = `a` + ?,`b` = `b` - ?,`c` = c + ?', $query->buildReplaceSql());
+        $this->assertEquals([4, 5, 6], $query->getBinds());
+    }
 }


### PR DESCRIPTION
* 查询构建器 `fieldRaw()`、`joinRaw()`、`whereRaw()`、`orWhereRaw()`、`groupRaw()`、`havingRaw()`、`orderRaw()`、`setFieldExp()`、`setFieldInc()`、`setFieldDec()` 支持传参数绑定

* 优化 setFieldInc()、setFieldDec() 不再使用参数拼接