### PR TITLE
修复phar包workerman环境下队列进程未设置静态属性值

### DIFF
--- a/src/Components/queue/src/Process/WorkermanQueueConsumerProcess.php
+++ b/src/Components/queue/src/Process/WorkermanQueueConsumerProcess.php
@@ -10,6 +10,7 @@ use Imi\Queue\Service\QueueService;
 use Imi\Workerman\Process\Annotation\Process;
 use Imi\Workerman\Process\BaseProcess;
 use Imi\Workerman\Process\ProcessManager;
+use Imi\Workerman\Server\Server as WorkermanServerUtil;
 use Imi\Workerman\Server\WorkermanServerWorker;
 use Workerman\Worker;
 

--- a/src/Components/queue/src/Process/WorkermanQueueConsumerProcess.php
+++ b/src/Components/queue/src/Process/WorkermanQueueConsumerProcess.php
@@ -31,6 +31,10 @@ if (\Imi\Util\Imi::checkAppType('workerman'))
         {
             WorkermanServerWorker::clearAll();
 
+            if (IMI_IN_PHAR)
+            {
+                WorkermanServerUtil::initWorkermanWorker('WorkermanQueue');
+            }
             $imiQueue = $this->imiQueue;
             foreach ($imiQueue->getList() as $name => $arrayConfig)
             {


### PR DESCRIPTION
修复Phar包开启队列后由于未指定pidFile目录,队列进程启动失败
```
[2023-03-30 14:13:27] imi.INFO: Process start [QueueConsumer]. pid: 13197
Workerman[./build/imi.phar] start in DEBUG mode
file_put_contents(phar:///project-websocket/build/imi.phar/vendor/workerman/workerman/../workerman.log): Failed to open stream: phar error: open mode append not supported in file phar:///project-websocket/build/imi.phar/vendor/workerman/workerman/Worker.php on line 2226
fopen(phar:///project-websocket/build/imi.phar/vendor/workerman/workerman/../_project-websocket_build_imi.phar.pid.lock): Failed to open stream: phar error: open mode append not supported in file phar:///project-websocket/build/imi.phar/vendor/workerman/workerman/Worker.php on line 642
file_put_contents(phar:///project-websocket/build/imi.phar/vendor/workerman/workerman/../_project-websocket_build_imi.phar.pid): Failed to open stream: phar error: write operations disabled by the php.ini setting phar.readonly in file phar:///project-websocket/build/imi.phar/vendor/workerman/workerman/Worker.php on line 1337
```