### PR TITLE
修复 MySQL 的 json 操作时，无法用双引号把字段名括起来

### DIFF
--- a/src/Components/swoole/tests/unit/Component/Tests/Db/Swoole/QueryCurdTest.php
+++ b/src/Components/swoole/tests/unit/Component/Tests/Db/Swoole/QueryCurdTest.php
@@ -30,5 +30,5 @@ class QueryCurdTest extends QueryCurdBaseTest
      *
      * @var string
      */
-    protected $expectedTestJsonSelectSql = 'select * from `tb_test_json` where `json_data`->"$.uid" = :p1';
+    protected $expectedTestJsonSelectSql = 'select * from `tb_test_json` where `json_data`->\'$.uid\' = :p1';
 }

--- a/src/Db/Mysql/Query/Builder/UpdateBuilder.php
+++ b/src/Db/Mysql/Query/Builder/UpdateBuilder.php
@@ -116,7 +116,7 @@ class UpdateBuilder extends BaseBuilder
             $item = $field . '=JSON_SET(' . $field;
             foreach ($options as $option)
             {
-                $item .= ',"$.' . implode('.', $option['jsonKeywords']) . '",' . ($option['raw'] ?? $option['valueParam']);
+                $item .= ',\'$.' . implode('.', $option['jsonKeywords']) . '\',' . ($option['raw'] ?? $option['valueParam']);
             }
             $result[] = $item . ')';
         }

--- a/src/Db/Mysql/Query/MysqlQuery.php
+++ b/src/Db/Mysql/Query/MysqlQuery.php
@@ -103,7 +103,7 @@ class MysqlQuery extends Query
         }
         if (null !== $jsonKeywords)
         {
-            $result .= '->"$.' . implode('.', $jsonKeywords) . '"';
+            $result .= '->\'$.' . implode('.', $jsonKeywords) . '\'';
         }
         if (!Text::isEmpty($alias))
         {

--- a/tests/unit/Component/Tests/Db/Mysqli/QueryCurdTest.php
+++ b/tests/unit/Component/Tests/Db/Mysqli/QueryCurdTest.php
@@ -30,5 +30,5 @@ class QueryCurdTest extends QueryCurdBaseTest
      *
      * @var string
      */
-    protected $expectedTestJsonSelectSql = 'select * from `tb_test_json` where `json_data`->"$.uid" = :p1';
+    protected $expectedTestJsonSelectSql = 'select * from `tb_test_json` where `json_data`->\'$.uid\' = :p1';
 }

--- a/tests/unit/Component/Tests/Db/Pdo/QueryCurdTest.php
+++ b/tests/unit/Component/Tests/Db/Pdo/QueryCurdTest.php
@@ -30,5 +30,5 @@ class QueryCurdTest extends QueryCurdBaseTest
      *
      * @var string
      */
-    protected $expectedTestJsonSelectSql = 'select * from `tb_test_json` where `json_data`->"$.uid" = :p1';
+    protected $expectedTestJsonSelectSql = 'select * from `tb_test_json` where `json_data`->\'$.uid\' = :p1';
 }

--- a/tests/unit/Component/Tests/Db/QueryCurdBaseTest.php
+++ b/tests/unit/Component/Tests/Db/QueryCurdBaseTest.php
@@ -396,7 +396,7 @@ abstract class QueryCurdBaseTest extends BaseTest
     public function testJson(): void
     {
         $query = Db::query($this->poolName);
-        $jsonStr = '{"uid": "' . ($uid = uniqid('', true)) . '", "name": "aaa", "list1": [{"id": 1}]}';
+        $jsonStr = '{"uid": "' . ($uid = uniqid('', true)) . '", "name": "aaa", "list1": [{"id": 1}], "测试": {"值": "imi"}}';
         // 插入数据
         $insertResult = $query->from($this->tableTestJson)->insert([
             'json_data' => $jsonStr,
@@ -415,11 +415,12 @@ abstract class QueryCurdBaseTest extends BaseTest
             'json_data->name'        => 'bbb',
             'json_data->list1[0].id' => '2',
             'json_data->list2'       => [1, 2, 3],
+            'json_data->"测试"."值"'    => 'imi niubi',
         ]);
         $result = $query->from($this->tableTestJson)->where('json_data->uid', '=', $uid)->order('json_data->uid')->select();
         $this->assertEquals([
             'id'        => $id,
-            'json_data' => '{"a": "1", "uid": "' . $uid . '", "name": "bbb", "list1": [{"id": "2"}], "list2": [1, 2, 3]}',
+            'json_data' => '{"a": "1", "uid": "' . $uid . '", "name": "bbb", "list1": [{"id": "2"}], "list2": [1, 2, 3], "测试": {"值": "imi niubi"}}',
         ], $result->get());
     }
 


### PR DESCRIPTION
fix #493