### PR TITLE
修复 Model::query() 查询动态指定不存在的字段，序列化时不返回该字段

### DIFF
--- a/src/Model/ModelQueryResult.php
+++ b/src/Model/ModelQueryResult.php
@@ -310,11 +310,12 @@ class ModelQueryResult extends Result
 
     private function parseFieldNames(array $serializableFieldNames, array $fieldNames): array
     {
-        foreach ($fieldNames as $i => $name)
+        foreach ($fieldNames as &$name)
         {
-            if (!isset($serializableFieldNames[$name]) && !\in_array($name, $serializableFieldNames))
+            // @deprecated 3.0 将废弃动态字段名
+            if (!isset($serializableFieldNames[$name]) && false !== ($index = array_search($name, $serializableFieldNames)))
             {
-                unset($fieldNames[$i]);
+                $name = $index;
             }
         }
 

--- a/tests/unit/Component/Tests/ModelTest.php
+++ b/tests/unit/Component/Tests/ModelTest.php
@@ -392,21 +392,23 @@ class ModelTest extends BaseTest
         ['id' => $id] = $args;
 
         /** @var Member $record */
-        $record = Member::query()->fieldRaw('*, 123 as notInJson')->where('id', '=', $id)->select()->get();
+        $record = Member::query()->fieldRaw('*, 123 as notInJson, 456 as tmpField')->where('id', '=', $id)->select()->get();
         $this->assertEquals([
             'id'        => $id,
             'username'  => '1',
             'password'  => 'pw2',
             'notInJson' => 123,
+            'tmpField'  => 456,
         ], $record->convertToArray());
 
-        $list = Member::query()->fieldRaw('*, 123 as notInJson')->where('id', '=', $id)->select()->getArray();
+        $list = Member::query()->fieldRaw('*, 123 as notInJson, 456 as tmpField')->where('id', '=', $id)->select()->getArray();
         $this->assertEquals([
             [
                 'id'        => $id,
                 'username'  => '1',
                 'password'  => 'pw2',
                 'notInJson' => 123,
+                'tmpField'  => 456,
             ],
         ], Member::convertListToArray($list));
     }


### PR DESCRIPTION
此改进太过激进，许多用户反馈问题，暂时将此特性回归，在 3.0 时考虑废弃此特性

fix #510