### PR TITLE
修复非 POST 请求使用 getParsedBody() 无法获取 JSON 反序列化数据

### DIFF
--- a/src/Util/Http/ServerRequest.php
+++ b/src/Util/Http/ServerRequest.php
@@ -301,7 +301,7 @@ class ServerRequest extends \Imi\Util\Http\Request implements IServerRequest
             {
                 $contentType = strtolower(trim(explode(';', $contentType, 2)[0]));
                 // post
-                if ('POST' === $this->getMethod() && \in_array($contentType, [
+                if (\in_array($contentType, [
                     MediaType::APPLICATION_FORM_URLENCODED,
                     MediaType::MULTIPART_FORM_DATA,
                 ]))

--- a/tests/unit/Component/Tests/Util/Http/ServerRequestTest.php
+++ b/tests/unit/Component/Tests/Util/Http/ServerRequestTest.php
@@ -143,6 +143,28 @@ class ServerRequestTest extends BaseTest
         $request = $request->{$changeMethod}(['name' => 'imi']);
         $this->assertEquals(['name' => 'imi'], $request->getParsedBody());
 
+        // form
+        $request = new class() extends ServerRequest {
+            /**
+             * {@inheritDoc}
+             */
+            protected function initBody(): void
+            {
+                $this->post = ['name' => 'imi'];
+            }
+        };
+        foreach ([
+            MediaType::APPLICATION_FORM_URLENCODED,
+            MediaType::MULTIPART_FORM_DATA,
+        ] as $contentType)
+        {
+            $request->setHeader(RequestHeader::CONTENT_TYPE, $contentType);
+            $requestTmp = $request->withMethod(RequestMethod::POST);
+            $this->assertEquals(['name' => 'imi'], $requestTmp->getParsedBody());
+            $requestTmp = $request->withMethod(RequestMethod::PUT);
+            $this->assertEquals(['name' => 'imi'], $requestTmp->getParsedBody());
+        }
+
         // json array
         Config::set('@server.' . __CLASS__ . '.jsonBodyIsObject', false);
         $request = new ServerRequest();


### PR DESCRIPTION
fix #521