### PR TITLE
数据库迁移组件文档中,生成同步命令由migration/patch 修改migration/dump

### DIFF
--- a/doc/components/orm/migration.md
+++ b/doc/components/orm/migration.md
@@ -39,13 +39,13 @@ vendor/bin/imi-swoole migration/patch -f
 **输出到命令行：**
 
 ```shell
-vendor/bin/imi-swoole migration/patch
+vendor/bin/imi-swoole migration/dump
 ```
 
 **保存到文件：**
 
 ```shell
-vendor/bin/imi-swoole migration/patch -f "文件名"
+vendor/bin/imi-swoole migration/dump -f "文件名"
 ```
 
 ### 通用参数


### PR DESCRIPTION
原数据库迁移组件文档中，生成同步命令示例错误，由 migration/patch 命令修改为 migration/dump