### PR TITLE
修复查询构建器 `join` 方法传入 `$where` 参数的报错

### DIFF
--- a/doc/components/orm/migration.md
+++ b/doc/components/orm/migration.md
@@ -39,13 +39,13 @@ vendor/bin/imi-swoole migration/patch -f
 **输出到命令行：**
 
 ```shell
-vendor/bin/imi-swoole migration/patch
+vendor/bin/imi-swoole migration/dump
 ```
 
 **保存到文件：**
 
 ```shell
-vendor/bin/imi-swoole migration/patch -f "文件名"
+vendor/bin/imi-swoole migration/dump -f "文件名"
 ```
 
 ### 通用参数

--- a/src/Db/Query/Join.php
+++ b/src/Db/Query/Join.php
@@ -186,7 +186,7 @@ class Join implements IJoin
         $result = $this->type . ' join ' . $this->table->toString($query) . ' on ' . $query->fieldQuote($this->left ?? '') . $this->operation . $query->fieldQuote($this->right ?? '');
         if ($this->where instanceof IBaseWhere)
         {
-            $result .= ' ' . $this->where->toString($query);
+            $result .= ' and ' . $this->where->toStringWithoutLogic($query);
         }
 
         return $result;

--- a/src/Db/Query/Join.php
+++ b/src/Db/Query/Join.php
@@ -46,12 +46,10 @@ class Join implements IJoin
     public function __construct(IQuery $query, ?string $table = null, ?string $left = null, ?string $operation = null, ?string $right = null, ?string $tableAlias = null, ?IBaseWhere $where = null, string $type = 'inner')
     {
         $this->table = $thisTable = new Table();
-        if (null !== $table)
-        {
+        if (null !== $table) {
             $thisTable->setValue($table, $query);
         }
-        if (null !== $tableAlias)
-        {
+        if (null !== $tableAlias) {
             $thisTable->setAlias($tableAlias);
         }
         $this->left = $left;
@@ -179,14 +177,12 @@ class Join implements IJoin
      */
     public function toString(IQuery $query): string
     {
-        if ($this->isRaw)
-        {
+        if ($this->isRaw) {
             return $this->rawSQL;
         }
         $result = $this->type . ' join ' . $this->table->toString($query) . ' on ' . $query->fieldQuote($this->left ?? '') . $this->operation . $query->fieldQuote($this->right ?? '');
-        if ($this->where instanceof IBaseWhere)
-        {
-            $result .= ' and ' . $this->where->toStringWithoutLogic($query);
+        if ($this->where instanceof IBaseWhere) {
+            $result .= ' ' . $this->where->getLogicalOperator() . ' ' . $this->where->toStringWithoutLogic($query);
         }
 
         return $result;
@@ -197,12 +193,9 @@ class Join implements IJoin
      */
     public function getBinds(): array
     {
-        if ($this->where instanceof IBaseWhere)
-        {
+        if ($this->where instanceof IBaseWhere) {
             return $this->where->getBinds();
-        }
-        else
-        {
+        } else {
             return $this->binds;
         }
     }

--- a/src/Db/Query/Join.php
+++ b/src/Db/Query/Join.php
@@ -46,10 +46,12 @@ class Join implements IJoin
     public function __construct(IQuery $query, ?string $table = null, ?string $left = null, ?string $operation = null, ?string $right = null, ?string $tableAlias = null, ?IBaseWhere $where = null, string $type = 'inner')
     {
         $this->table = $thisTable = new Table();
-        if (null !== $table) {
+        if (null !== $table)
+        {
             $thisTable->setValue($table, $query);
         }
-        if (null !== $tableAlias) {
+        if (null !== $tableAlias)
+        {
             $thisTable->setAlias($tableAlias);
         }
         $this->left = $left;
@@ -177,11 +179,13 @@ class Join implements IJoin
      */
     public function toString(IQuery $query): string
     {
-        if ($this->isRaw) {
+        if ($this->isRaw)
+        {
             return $this->rawSQL;
         }
         $result = $this->type . ' join ' . $this->table->toString($query) . ' on ' . $query->fieldQuote($this->left ?? '') . $this->operation . $query->fieldQuote($this->right ?? '');
-        if ($this->where instanceof IBaseWhere) {
+        if ($this->where instanceof IBaseWhere)
+        {
             $result .= ' ' . $this->where->getLogicalOperator() . ' ' . $this->where->toStringWithoutLogic($query);
         }
 
@@ -193,9 +197,12 @@ class Join implements IJoin
      */
     public function getBinds(): array
     {
-        if ($this->where instanceof IBaseWhere) {
+        if ($this->where instanceof IBaseWhere)
+        {
             return $this->where->getBinds();
-        } else {
+        }
+        else
+        {
             return $this->binds;
         }
     }

--- a/tests/unit/Component/Tests/Db/QueryCurdBaseTest.php
+++ b/tests/unit/Component/Tests/Db/QueryCurdBaseTest.php
@@ -71,9 +71,9 @@ abstract class QueryCurdBaseTest extends BaseTest
             'title'     => 'title-insert',
             'content'   => 'content-insert',
         ])
-            ->setField('time', '2019-06-21 00:00:00')
-            ->from($this->tableArticle)
-            ->insert();
+        ->setField('time', '2019-06-21 00:00:00')
+        ->from($this->tableArticle)
+        ->insert();
         $id2 = $result->getLastInsertId();
         $record = $query->from($this->tableArticle)->where('id', '=', $id2)->select()->get();
         Assert::assertEquals([
@@ -208,11 +208,11 @@ abstract class QueryCurdBaseTest extends BaseTest
             'page_count'    => 1,
         ];
         $result = Db::query($this->poolName)->from($this->tableArticle)
-            ->bindValues([
-                ':id'  => $ids[1],
-            ])
-            ->whereRaw('id = :id')
-            ->paginate(1, 1);
+                             ->bindValues([
+                                 ':id'  => $ids[1],
+                             ])
+                             ->whereRaw('id = :id')
+                             ->paginate(1, 1);
         $this->assertEquals($expectedData, $result->toArray());
     }
 
@@ -465,32 +465,36 @@ abstract class QueryCurdBaseTest extends BaseTest
     public function testRawBinds(): void
     {
         $query = Db::query()->from('test')
-            ->fieldRaw('test.*, ?', null, ['imi'])
-            ->joinRaw('join test2 on test.id = test2.id and test2.id2 = ?', [1])
-            ->whereRaw('test.id = ?', 'and', [2])
-            ->orWhereRaw('test.id = ?', [3])
-            ->groupRaw('test.id, ?', [4])
-            ->havingRaw('test.id = ?', 'and', [5])
-            ->orderRaw('field(test.id, ?, ?)', [6, 7]);
+                            ->fieldRaw('test.*, ?', null, ['imi'])
+                            ->joinRaw('join test2 on test.id = test2.id and test2.id2 = ?', [1])
+                            ->whereRaw('test.id = ?', 'and', [2])
+                            ->orWhereRaw('test.id = ?', [3])
+                            ->groupRaw('test.id, ?', [4])
+                            ->havingRaw('test.id = ?', 'and', [5])
+                            ->orderRaw('field(test.id, ?, ?)', [6, 7])
+        ;
         $this->assertEquals('select test.*, ? from `test` join test2 on test.id = test2.id and test2.id2 = ? where test.id = ? or test.id = ? group by test.id, ? having test.id = ? order by field(test.id, ?, ?)', $query->buildSelectSql());
         $this->assertEquals(['imi', 1, 2, 3, 4, 5, 6, 7], $query->getBinds());
     }
 
     public function testSetFieldExp(): void
     {
-        $query = Db::query()->from('test')->setFieldExp('c', '1 + ?', [1]);
+        $query = Db::query()->from('test')->setFieldExp('c', '1 + ?', [1])
+        ;
         $this->assertEquals('insert into `test` (`c`) values(1 + ?)', $query->buildInsertSql());
         $this->assertEquals([1], $query->getBinds());
 
         $query = Db::query()->from('test')->setFieldInc('a', 1)
-            ->setFieldDec('b', 2)
-            ->setFieldExp('c', 'c + :c', [':c' => 3]);
+                                          ->setFieldDec('b', 2)
+                                          ->setFieldExp('c', 'c + :c', [':c' => 3])
+        ;
         $this->assertEquals('update `test` set `a` = `a` + :fip1,`b` = `b` - :fdp2,`c` = c + :c', $query->buildUpdateSql());
         $this->assertEquals([':fip1' => 1, ':fdp2' => 2, ':c' => 3], $query->getBinds());
 
         $query = Db::query()->from('test')->setFieldInc('a', 4)
-            ->setFieldDec('b', 5)
-            ->setFieldExp('c', 'c + :c', [':c' => 6]);
+                                          ->setFieldDec('b', 5)
+                                          ->setFieldExp('c', 'c + :c', [':c' => 6])
+        ;
         $this->assertEquals('replace into `test` set `a` = `a` + :fip1,`b` = `b` - :fdp2,`c` = c + :c', $query->buildReplaceSql());
         $this->assertEquals([':fip1' => 4, ':fdp2' => 5, ':c' => 6], $query->getBinds());
     }
@@ -523,13 +527,11 @@ abstract class QueryCurdBaseTest extends BaseTest
         $this->assertEquals('db_imi2', $database->toString($query));
     }
 
-    public function testJoinWhere()
+    public function testJoinWhere(): void
     {
-        $query = Db::query();
-
         $query = Db::query()->from('test')
             ->join('test2', 'test.id', '=', 'test2.id', null, new Where('test2.id2', '=', 1));
-        $this->assertEquals('select * from `test` join test2 on test.id = test2.id and test2.id2 = :p1', $query->buildSelectSql());
+        $this->assertEquals('select * from `test` inner join `test2` on `test`.`id`=`test2`.`id` and `test2`.`id2` = :p1', $query->buildSelectSql());
         $this->assertEquals([':p1' => 1], $query->getBinds());
     }
 }


### PR DESCRIPTION
join操作时，如果有where对象，原本使用toString获取拼接语句是错的，因修改为toStringWithoutLogic，同时与sql语句拼接时，缺少and