### PR TITLE
优化容器单例对象当 __construct() 或 __init() 有协程上下文切换，不会导致单例被覆盖

### DIFF
--- a/src/Components/amqp/src/Base/Traits/TAMQP.php
+++ b/src/Components/amqp/src/Base/Traits/TAMQP.php
@@ -15,7 +15,6 @@ use Imi\Aop\Annotation\Inject;
 use Imi\Bean\Annotation\AnnotationManager;
 use Imi\Bean\BeanFactory;
 use Imi\Log\Log;
-use Imi\Util\Imi;
 use PhpAmqpLib\Channel\AMQPChannel;
 use PhpAmqpLib\Connection\AbstractConnection;
 use PhpAmqpLib\Connection\AMQPStreamConnection;
@@ -73,8 +72,6 @@ trait TAMQP
      */
     protected ?string $poolName = null;
 
-    protected bool $isSwoole = false;
-
     /**
      * 初始化配置.
      */
@@ -93,7 +90,6 @@ trait TAMQP
         $this->publishers = $annotations[Publisher::class];
         $this->consumers = $annotations[Consumer::class];
         $this->connectionAnnotation = $annotations[Connection::class][0] ?? null;
-        $this->isSwoole = Imi::checkAppType('swoole');
     }
 
     /**

--- a/src/Components/swoole/src/Server/ConnectionContext/StoreHandler/Amqp.php
+++ b/src/Components/swoole/src/Server/ConnectionContext/StoreHandler/Amqp.php
@@ -9,7 +9,7 @@ use Imi\RequestContext;
 use Imi\Server\ConnectionContext\StoreHandler\Local;
 
 /**
- * @Bean(name="ConnectionContextAmqp", env="swoole")
+ * @Bean(name="ConnectionContextAmqp", env="swoole", recursion=false)
  */
 class Amqp extends Local
 {

--- a/src/Components/swoole/src/Server/Util/Amqp/AmqpServerConsumer.php
+++ b/src/Components/swoole/src/Server/Util/Amqp/AmqpServerConsumer.php
@@ -26,7 +26,13 @@ if (class_exists(\Imi\AMQP\Main::class))
      */
     class AmqpServerConsumer extends BaseConsumer
     {
-        protected AmqpServerUtil $amqpServerUtil;
+        protected ?AmqpServerUtil $amqpServerUtil;
+
+        public function __construct(?AmqpServerUtil $amqpServerUtil = null)
+        {
+            $this->amqpServerUtil = $amqpServerUtil;
+            parent::__construct();
+        }
 
         /**
          * {@inheritDoc}
@@ -34,7 +40,7 @@ if (class_exists(\Imi\AMQP\Main::class))
         public function initConfig(): void
         {
             /** @var AmqpServerUtil $amqpServerUtil */
-            $amqpServerUtil = $this->amqpServerUtil = RequestContext::getServerBean('AmqpServerUtil');
+            $amqpServerUtil = ($this->amqpServerUtil ??= RequestContext::getServerBean('AmqpServerUtil'));
             $this->exchanges = [$exchangeAnnotation = new Exchange($amqpServerUtil->getExchangeConfig())];
             $queueConfig = $amqpServerUtil->getQueueConfig();
             $queueName = ($queueConfig['name'] .= Worker::getWorkerId());

--- a/src/Components/swoole/src/Server/Util/Amqp/AmqpServerPublisher.php
+++ b/src/Components/swoole/src/Server/Util/Amqp/AmqpServerPublisher.php
@@ -23,6 +23,7 @@ if (class_exists(\Imi\AMQP\Main::class))
         public function __construct(?AmqpServerUtil $amqpServerUtil = null)
         {
             $this->amqpServerUtil = $amqpServerUtil;
+            parent::__construct();
         }
 
         /**

--- a/src/Components/swoole/src/Server/Util/Amqp/AmqpServerPublisher.php
+++ b/src/Components/swoole/src/Server/Util/Amqp/AmqpServerPublisher.php
@@ -18,7 +18,12 @@ if (class_exists(\Imi\AMQP\Main::class))
      */
     class AmqpServerPublisher extends BasePublisher
     {
-        protected AmqpServerUtil $amqpServerUtil;
+        protected ?AmqpServerUtil $amqpServerUtil;
+
+        public function __construct(?AmqpServerUtil $amqpServerUtil = null)
+        {
+            $this->amqpServerUtil = $amqpServerUtil;
+        }
 
         /**
          * {@inheritDoc}
@@ -26,7 +31,7 @@ if (class_exists(\Imi\AMQP\Main::class))
         public function initConfig(): void
         {
             /** @var AmqpServerUtil $amqpServerUtil */
-            $amqpServerUtil = $this->amqpServerUtil = RequestContext::getServerBean('AmqpServerUtil');
+            $amqpServerUtil = ($this->amqpServerUtil ??= RequestContext::getServerBean('AmqpServerUtil'));
             $this->exchanges = [new Exchange($amqpServerUtil->getExchangeConfig())];
             $this->poolName = $amqpServerUtil->getAmqpName() ?? AMQPPool::getDefaultPoolName();
         }

--- a/src/Components/swoole/src/Server/Util/AmqpServerUtil.php
+++ b/src/Components/swoole/src/Server/Util/AmqpServerUtil.php
@@ -18,7 +18,7 @@ use Imi\Worker;
 if (class_exists(\Imi\AMQP\Main::class))
 {
     /**
-     * @Bean(name="AmqpServerUtil", env="swoole", recursion=false)
+     * @Bean(name="AmqpServerUtil", env="swoole")
      */
     class AmqpServerUtil extends LocalServerUtil
     {

--- a/src/Components/swoole/src/Server/Util/AmqpServerUtil.php
+++ b/src/Components/swoole/src/Server/Util/AmqpServerUtil.php
@@ -61,7 +61,7 @@ if (class_exists(\Imi\AMQP\Main::class))
         {
             $server = RequestContext::getServer();
             $this->serverName = $server->getName();
-            $this->consumerInstance = $server->getBean($this->consumerClass);
+            $this->consumerInstance = $server->getBean($this->consumerClass, $this);
             $this->publisherInstance = $server->getBean($this->publisherClass, $this);
             Event::one('IMI.MAIN_SERVER.WORKER.EXIT', function () {
                 $this->subscribeEnable = false;

--- a/src/Components/swoole/src/Server/Util/AmqpServerUtil.php
+++ b/src/Components/swoole/src/Server/Util/AmqpServerUtil.php
@@ -18,7 +18,7 @@ use Imi\Worker;
 if (class_exists(\Imi\AMQP\Main::class))
 {
     /**
-     * @Bean(name="AmqpServerUtil", env="swoole")
+     * @Bean(name="AmqpServerUtil", env="swoole", recursion=false)
      */
     class AmqpServerUtil extends LocalServerUtil
     {

--- a/src/Components/swoole/src/Server/Util/LocalServerUtil.php
+++ b/src/Components/swoole/src/Server/Util/LocalServerUtil.php
@@ -21,7 +21,7 @@ use Imi\Util\Process\ProcessType;
 use Imi\Worker;
 
 /**
- * @Bean(name="LocalServerUtil", env="swoole")
+ * @Bean(name="LocalServerUtil", env="swoole", recursion=false)
  */
 class LocalServerUtil implements ISwooleServerUtil
 {

--- a/src/Components/swoole/src/Server/Util/LocalServerUtil.php
+++ b/src/Components/swoole/src/Server/Util/LocalServerUtil.php
@@ -21,7 +21,7 @@ use Imi\Util\Process\ProcessType;
 use Imi\Worker;
 
 /**
- * @Bean(name="LocalServerUtil", env="swoole", recursion=false)
+ * @Bean(name="LocalServerUtil", env="swoole")
  */
 class LocalServerUtil implements ISwooleServerUtil
 {

--- a/src/Components/swoole/src/Server/Util/RedisServerUtil.php
+++ b/src/Components/swoole/src/Server/Util/RedisServerUtil.php
@@ -19,7 +19,7 @@ use Imi\Util\Process\ProcessType;
 use Imi\Worker;
 
 /**
- * @Bean(name="RedisServerUtil", env="swoole")
+ * @Bean(name="RedisServerUtil", env="swoole", recursion=false)
  */
 class RedisServerUtil extends LocalServerUtil
 {

--- a/src/Components/swoole/src/Server/Util/RedisServerUtil.php
+++ b/src/Components/swoole/src/Server/Util/RedisServerUtil.php
@@ -19,7 +19,7 @@ use Imi\Util\Process\ProcessType;
 use Imi\Worker;
 
 /**
- * @Bean(name="RedisServerUtil", env="swoole", recursion=false)
+ * @Bean(name="RedisServerUtil", env="swoole")
  */
 class RedisServerUtil extends LocalServerUtil
 {

--- a/src/Server/ConnectionContext/StoreHandler.php
+++ b/src/Server/ConnectionContext/StoreHandler.php
@@ -11,7 +11,7 @@ use Imi\Server\ConnectionContext\StoreHandler\IHandler;
 /**
  * 连接上下文存储处理器-总.
  *
- * @Bean("ConnectionContextStore")
+ * @Bean(name="ConnectionContextStore", recursion=false)
  */
 class StoreHandler implements IHandler
 {


### PR DESCRIPTION
顺便修复极端情况下某些类初始化不完全