### PR TITLE
修复当开启 Redis 序列化时，geoAdd() 会报错：ERR value is not a valid float

### DIFF
--- a/doc/base/qa.md
+++ b/doc/base/qa.md
@@ -97,3 +97,13 @@ net.ipv4.tcp_wmem = 4096 32768 262142
 * Swoole 常驻内存并且有协程，所以 `worker_num` 建议设为 CPU 的 1-2 倍。
 
 * Workerman 常驻内存但依然是阻塞的，`count` 可参考 php-fpm 进程数的配置，并酌情减少一定的数量。
+
+## Redis 报错 ERR value is not a valid float
+
+该问题主要出现在，当启用 Redis 序列化时候，方法的参数值会被序列化后传输。
+
+官方认为这不算 BUG：<https://github.com/phpredis/phpredis/issues/1549>。
+
+imi v2.1.53 中对 `geoAdd()` 做了兼容处理。
+
+如果你在调用其它 Redis 方法报这个类似的错误，可以尝试关闭 Redis 连接池配置中的序列化，然后到 imi 的 github 提 issue，我们会在后续版本中做兼容处理。

--- a/src/Redis/RedisHandler.php
+++ b/src/Redis/RedisHandler.php
@@ -547,6 +547,36 @@ class RedisHandler
     }
 
     /**
+     * geoadd.
+     *
+     * 当开启序列化后，经纬度会被序列化，并返回错误：ERR value is not a valid float
+     *
+     * 如下链接，官方认为这不算 BUG，所以这里做了一个兼容处理
+     *
+     * @see https://github.com/phpredis/phpredis/issues/1549
+     *
+     * @param float|string $lng
+     * @param float|string $lat
+     * @param mixed        ...$other_triples_and_options
+     *
+     * @return mixed
+     */
+    public function geoadd(string $key, $lng, $lat, string $member, ...$other_triples_and_options)
+    {
+        $redis = $this->redis;
+        $serializer = $redis->getOption(\Redis::OPT_SERIALIZER);
+        $redis->setOption(\Redis::OPT_SERIALIZER, \Redis::SERIALIZER_NONE);
+        try
+        {
+            return $redis->geoadd($key, $lng, $lat, $member, ...$other_triples_and_options);
+        }
+        finally
+        {
+            $redis->setOption(\Redis::OPT_SERIALIZER, $serializer);
+        }
+    }
+
+    /**
      * 是否为集群.
      */
     public function isCluster(): bool

--- a/tests/unit/Component/Tests/RedisTest.php
+++ b/tests/unit/Component/Tests/RedisTest.php
@@ -137,4 +137,15 @@ class RedisTest extends BaseTest
         }
         $this->assertEquals($excepted, $map);
     }
+
+    public function testGeoAdd(): void
+    {
+        foreach ([
+            'redis_test', // 开启序列化
+            'redis_cache', // 禁用序列化
+        ] as $poolName)
+        {
+            $this->assertNotFalse(Redis::use(static fn (RedisHandler $redis) => $redis->geoAdd('imi:geo', 120.31858, 31.49881, $poolName), $poolName));
+        }
+    }
 }

--- a/tests/unit/Component/Tests/RedisTest.php
+++ b/tests/unit/Component/Tests/RedisTest.php
@@ -140,6 +140,10 @@ class RedisTest extends BaseTest
 
     public function testGeoAdd(): void
     {
+        if (\PHP_OS_FAMILY === 'Windows')
+        {
+            $this->markTestSkipped('Windows redis not support geo.');
+        }
         foreach ([
             'redis_test', // 开启序列化
             'redis_cache', // 禁用序列化


### PR DESCRIPTION
fix #578

这是 phpredis 扩展的一个陈年老bug，当启用 Redis 序列化时候，`geoAdd()` 的经纬度参数值会被序列化后传输。

官方认为这不算 BUG，所以这里做了一个兼容处理。

前人提问记录：<https://github.com/phpredis/phpredis/issues/1549>。