### PR TITLE
修复 ConnectionContextStore 初始化

### DIFF
--- a/src/Components/swoole/src/Server/ConnectionContext/Listener/AppInit.php
+++ b/src/Components/swoole/src/Server/ConnectionContext/Listener/AppInit.php
@@ -44,7 +44,7 @@ class AppInit implements IAppInitEventListener
             {
                 RequestContext::set('server', $server);
                 // @phpstan-ignore-next-line
-                $server->getBean('ConnectionContextStore')->init();
+                $server->getBean('ConnectionContextStore');
                 if (Imi::getClassPropertyValue('ServerGroup', 'status'))
                 {
                     /** @var \Imi\Server\Group\Handler\IGroupHandler $groupHandler */

--- a/src/Server/ConnectionContext/StoreHandler.php
+++ b/src/Server/ConnectionContext/StoreHandler.php
@@ -32,7 +32,7 @@ class StoreHandler implements IHandler
      */
     private ?IHandler $handler = null;
 
-    public function init(): void
+    public function __init(): void
     {
         $this->getHandler();
     }


### PR DESCRIPTION
设置了 `@Bean(recursion=false)`，可以在 `__init()` 里执行初始化，避免启动时有大量请求进来，导致后续正确获取到正确的 Handler