### PR TITLE
[3.0] 重构 RequestContext

### DIFF
--- a/doc/core/requestContext.md
+++ b/doc/core/requestContext.md
@@ -67,3 +67,21 @@ $result = \Imi\RequestContext::remember('myKey3', function () {
     return 1 + 2;
 });
 ```
+
+### 推迟执行
+
+当协程释放时触发，先进后出
+
+```php
+use function Yurun\Swoole\Coroutine\goWait;
+$result = [];
+goWait(static function () use (&$result): void {
+    RequestContext::defer(static function () use (&$result): void {
+        $result[] = 1;
+    });
+    RequestContext::defer(static function () use (&$result): void {
+        $result[] = 2;
+    });
+}, -1, true);
+var_dump($result); // [2, 1]
+```

--- a/src/Components/swoole/src/Context/CoroutineContextManager.php
+++ b/src/Components/swoole/src/Context/CoroutineContextManager.php
@@ -26,11 +26,11 @@ class CoroutineContextManager implements IContextManager
     /**
      * {@inheritDoc}
      */
-    public function create(string $flag, array $data = []): \ArrayObject
+    public function create(string $id, array $data = []): \ArrayObject
     {
-        if ($flag > -1)
+        if ($id > -1)
         {
-            $context = Coroutine::getContext((int) $flag);
+            $context = Coroutine::getContext((int) $id);
             // destroy
             if (!($context['__bindDestroy'] ?? false))
             {
@@ -49,28 +49,28 @@ class CoroutineContextManager implements IContextManager
         }
         else
         {
-            if (isset($this->contexts[$flag]))
+            if (isset($this->contexts[$id]))
             {
-                throw new ContextExistsException(sprintf('Context %s already exists!', $flag));
+                throw new ContextExistsException(sprintf('Context %s already exists!', $id));
             }
 
-            return $this->contexts[$flag] = new \ArrayObject($data, \ArrayObject::ARRAY_AS_PROPS);
+            return $this->contexts[$id] = new \ArrayObject($data, \ArrayObject::ARRAY_AS_PROPS);
         }
     }
 
     /**
      * {@inheritDoc}
      */
-    public function destroy(string $flag): bool
+    public function destroy(string $id): bool
     {
-        if ($flag > -1)
+        if ($id > -1)
         {
             return false; // 协程退出时自动销毁，无法手动销毁
         }
-        elseif (isset($this->contexts[$flag]))
+        elseif (isset($this->contexts[$id]))
         {
             Event::trigger('IMI.REQUEST_CONTENT.DESTROY');
-            unset($this->contexts[$flag]);
+            unset($this->contexts[$id]);
 
             return true;
         }
@@ -83,11 +83,11 @@ class CoroutineContextManager implements IContextManager
     /**
      * {@inheritDoc}
      */
-    public function get(string $flag, bool $autoCreate = false): \ArrayObject
+    public function get(string $id, bool $autoCreate = false): \ArrayObject
     {
-        if ($flag > -1)
+        if ($id > -1)
         {
-            $context = Coroutine::getContext((int) $flag);
+            $context = Coroutine::getContext((int) $id);
             // destroy
             if (!($context['__bindDestroy'] ?? false))
             {
@@ -99,38 +99,38 @@ class CoroutineContextManager implements IContextManager
         }
         else
         {
-            if (!isset($this->contexts[$flag]))
+            if (!isset($this->contexts[$id]))
             {
                 if ($autoCreate)
                 {
-                    return $this->create($flag);
+                    return $this->create($id);
                 }
-                throw new ContextNotFoundException(sprintf('Context %s does not exists!', $flag));
+                throw new ContextNotFoundException(sprintf('Context %s does not exists!', $id));
             }
 
-            return $this->contexts[$flag];
+            return $this->contexts[$id];
         }
     }
 
     /**
      * {@inheritDoc}
      */
-    public function exists(string $flag): bool
+    public function exists(string $id): bool
     {
-        if ($flag > -1)
+        if ($id > -1)
         {
-            return Coroutine::exists($flag);
+            return Coroutine::exists($id);
         }
         else
         {
-            return isset($this->contexts[$flag]);
+            return isset($this->contexts[$id]);
         }
     }
 
     /**
      * {@inheritDoc}
      */
-    public function getCurrentFlag(): string
+    public function getCurrentId(): string
     {
         return (string) Coroutine::getCid();
     }

--- a/src/Components/swoole/tests/unit/Component/Tests/RequestContextTest.php
+++ b/src/Components/swoole/tests/unit/Component/Tests/RequestContextTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Imi\Test\Component\Tests;
+namespace Imi\Swoole\Test\Component\Tests;
 
 use Imi\RequestContext;
 use Imi\Test\BaseTest;

--- a/src/Components/swoole/tests/unit/Component/Tests/RequestContextTest.php
+++ b/src/Components/swoole/tests/unit/Component/Tests/RequestContextTest.php
@@ -7,6 +7,8 @@ namespace Imi\Swoole\Test\Component\Tests;
 use Imi\RequestContext;
 use Imi\Test\BaseTest;
 
+use function Yurun\Swoole\Coroutine\goWait;
+
 /**
  * @testdox RequestContext
  */
@@ -14,12 +16,16 @@ class RequestContextTest extends BaseTest
 {
     public function testDefer(): void
     {
-        $success = false;
-        RequestContext::defer(static function () use (&$success): void {
-            $success = true;
-        });
-        RequestContext::destroy();
-        $this->assertTrue($success);
+        $result = [];
+        goWait(static function () use (&$result): void {
+            RequestContext::defer(static function () use (&$result): void {
+                $result[] = 1;
+            });
+            RequestContext::defer(static function () use (&$result): void {
+                $result[] = 2;
+            });
+        }, -1, true);
+        $this->assertEquals([2, 1], $result);
     }
 
     public function testRemember(): void

--- a/src/Core/Context/ContextData.php
+++ b/src/Core/Context/ContextData.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Imi\Core\Context;
+
+class ContextData extends \ArrayObject
+{
+    protected \SplStack $deferCallbacks;
+
+    public function __construct(mixed $input = [])
+    {
+        parent::__construct($input, self::ARRAY_AS_PROPS, \ArrayIterator::class);
+        $this->deferCallbacks = new \SplStack();
+    }
+
+    /**
+     * 推迟执行，当协程释放时触发，先进后出.
+     */
+    public function defer(callable $callback): void
+    {
+        $this->deferCallbacks[] = $callback;
+    }
+
+    /**
+     * 获取推迟执行任务栈.
+     */
+    public function getDeferCallbacks(): \SplStack
+    {
+        return $this->deferCallbacks;
+    }
+}

--- a/src/Core/Context/Contract/IContextManager.php
+++ b/src/Core/Context/Contract/IContextManager.php
@@ -4,30 +4,32 @@ declare(strict_types=1);
 
 namespace Imi\Core\Context\Contract;
 
+use Imi\Core\Context\ContextData;
+
 interface IContextManager
 {
     /**
      * 创建上下文.
      */
-    public function create(string $id, array $data = []): \ArrayObject;
+    public function create(string|int $id, array $data = []): ContextData;
 
     /**
      * 销毁上下文.
      */
-    public function destroy(string $id): bool;
+    public function destroy(string|int $id): bool;
 
     /**
      * 获取上下文.
      */
-    public function get(string $id, bool $autoCreate = false): \ArrayObject;
+    public function get(string|int $id, bool $autoCreate = false): ContextData;
 
     /**
      * 上下文是否存在.
      */
-    public function exists(string $id): bool;
+    public function exists(string|int $id): bool;
 
     /**
      * 获取当前上下文标识.
      */
-    public function getCurrentId(): string;
+    public function getCurrentId(): string|int;
 }

--- a/src/Core/Context/Contract/IContextManager.php
+++ b/src/Core/Context/Contract/IContextManager.php
@@ -9,25 +9,25 @@ interface IContextManager
     /**
      * 创建上下文.
      */
-    public function create(string $flag, array $data = []): \ArrayObject;
+    public function create(string $id, array $data = []): \ArrayObject;
 
     /**
      * 销毁上下文.
      */
-    public function destroy(string $flag): bool;
+    public function destroy(string $id): bool;
 
     /**
      * 获取上下文.
      */
-    public function get(string $flag, bool $autoCreate = false): \ArrayObject;
+    public function get(string $id, bool $autoCreate = false): \ArrayObject;
 
     /**
      * 上下文是否存在.
      */
-    public function exists(string $flag): bool;
+    public function exists(string $id): bool;
 
     /**
      * 获取当前上下文标识.
      */
-    public function getCurrentFlag(): string;
+    public function getCurrentId(): string;
 }

--- a/src/Core/Context/DefaultContextManager.php
+++ b/src/Core/Context/DefaultContextManager.php
@@ -26,11 +26,11 @@ class DefaultContextManager implements IContextManager
     /**
      * {@inheritDoc}
      */
-    public function create(string $flag, array $data = []): \ArrayObject
+    public function create(string $id, array $data = []): \ArrayObject
     {
-        if (isset($this->contexts[$flag]))
+        if (isset($this->contexts[$id]))
         {
-            throw new ContextExistsException(sprintf('Context %s already exists!', $flag));
+            throw new ContextExistsException(sprintf('Context %s already exists!', $id));
         }
 
         // 脚本执行结束时自动销毁上下文
@@ -40,18 +40,18 @@ class DefaultContextManager implements IContextManager
             $this->bindAutoDestroy();
         }
 
-        return $this->contexts[$flag] = new \ArrayObject($data, \ArrayObject::ARRAY_AS_PROPS);
+        return $this->contexts[$id] = new \ArrayObject($data, \ArrayObject::ARRAY_AS_PROPS);
     }
 
     /**
      * {@inheritDoc}
      */
-    public function destroy(string $flag): bool
+    public function destroy(string $id): bool
     {
-        if (isset($this->contexts[$flag]))
+        if (isset($this->contexts[$id]))
         {
             Event::trigger('IMI.REQUEST_CONTENT.DESTROY');
-            unset($this->contexts[$flag]);
+            unset($this->contexts[$id]);
 
             return true;
         }
@@ -64,32 +64,32 @@ class DefaultContextManager implements IContextManager
     /**
      * {@inheritDoc}
      */
-    public function get(string $flag, bool $autoCreate = false): \ArrayObject
+    public function get(string $id, bool $autoCreate = false): \ArrayObject
     {
-        if (!isset($this->contexts[$flag]))
+        if (!isset($this->contexts[$id]))
         {
             if ($autoCreate)
             {
-                return $this->create($flag);
+                return $this->create($id);
             }
-            throw new ContextNotFoundException(sprintf('Context %s does not exists!', $flag));
+            throw new ContextNotFoundException(sprintf('Context %s does not exists!', $id));
         }
 
-        return $this->contexts[$flag];
+        return $this->contexts[$id];
     }
 
     /**
      * {@inheritDoc}
      */
-    public function exists(string $flag): bool
+    public function exists(string $id): bool
     {
-        return isset($this->contexts[$flag]);
+        return isset($this->contexts[$id]);
     }
 
     /**
      * {@inheritDoc}
      */
-    public function getCurrentFlag(): string
+    public function getCurrentId(): string
     {
         return 'default';
     }
@@ -99,9 +99,9 @@ class DefaultContextManager implements IContextManager
         register_shutdown_function(function (): void {
             if ($this->contexts)
             {
-                foreach ($this->contexts as $flag => $_)
+                foreach ($this->contexts as $id => $_)
                 {
-                    $this->destroy($flag);
+                    $this->destroy($id);
                 }
             }
         });

--- a/src/Core/Context/DefaultContextManager.php
+++ b/src/Core/Context/DefaultContextManager.php
@@ -17,7 +17,7 @@ class DefaultContextManager implements IContextManager
     /**
      * 上下文对象集合.
      *
-     * @var \ArrayObject[]
+     * @var ContextData[]
      */
     private array $contexts = [];
 
@@ -26,7 +26,7 @@ class DefaultContextManager implements IContextManager
     /**
      * {@inheritDoc}
      */
-    public function create(string $id, array $data = []): \ArrayObject
+    public function create(string|int $id, array $data = []): ContextData
     {
         if (isset($this->contexts[$id]))
         {
@@ -40,17 +40,23 @@ class DefaultContextManager implements IContextManager
             $this->bindAutoDestroy();
         }
 
-        return $this->contexts[$id] = new \ArrayObject($data, \ArrayObject::ARRAY_AS_PROPS);
+        return $this->contexts[$id] = new ContextData($data);
     }
 
     /**
      * {@inheritDoc}
      */
-    public function destroy(string $id): bool
+    public function destroy(string|int $id): bool
     {
         if (isset($this->contexts[$id]))
         {
+            // TODO: 实现新的连接管理器后移除
             Event::trigger('IMI.REQUEST_CONTENT.DESTROY');
+            $deferCallbacks = $this->contexts[$id]->getDeferCallbacks();
+            while (!$deferCallbacks->isEmpty())
+            {
+                $deferCallbacks->pop()();
+            }
             unset($this->contexts[$id]);
 
             return true;
@@ -64,7 +70,7 @@ class DefaultContextManager implements IContextManager
     /**
      * {@inheritDoc}
      */
-    public function get(string $id, bool $autoCreate = false): \ArrayObject
+    public function get(string|int $id, bool $autoCreate = false): ContextData
     {
         if (!isset($this->contexts[$id]))
         {
@@ -81,7 +87,7 @@ class DefaultContextManager implements IContextManager
     /**
      * {@inheritDoc}
      */
-    public function exists(string $id): bool
+    public function exists(string|int $id): bool
     {
         return isset($this->contexts[$id]);
     }
@@ -89,7 +95,7 @@ class DefaultContextManager implements IContextManager
     /**
      * {@inheritDoc}
      */
-    public function getCurrentId(): string
+    public function getCurrentId(): string|int
     {
         return 'default';
     }

--- a/src/Lock/Handler/BaseLock.php
+++ b/src/Lock/Handler/BaseLock.php
@@ -82,7 +82,7 @@ abstract class BaseLock implements ILockHandler
             return false;
         }
         $this->isLocked = true;
-        $this->lockCoId = RequestContext::getCurrentFlag();
+        $this->lockCoId = RequestContext::getCurrentId();
         $this->beginTime = microtime(true);
         if (null === $taskCallable)
         {
@@ -121,7 +121,7 @@ abstract class BaseLock implements ILockHandler
             return false;
         }
         $this->isLocked = true;
-        $this->lockCoId = RequestContext::getCurrentFlag();
+        $this->lockCoId = RequestContext::getCurrentId();
         $this->beginTime = microtime(true);
         if (null !== $taskCallable)
         {
@@ -185,7 +185,7 @@ abstract class BaseLock implements ILockHandler
      */
     public function isLocked(): bool
     {
-        return $this->isLocked && $this->lockCoId === RequestContext::getCurrentFlag();
+        return $this->isLocked && $this->lockCoId === RequestContext::getCurrentId();
     }
 
     /**

--- a/src/RequestContext.php
+++ b/src/RequestContext.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Imi;
 
 use Imi\Bean\Container;
+use Imi\Core\Context\ContextData;
 use Imi\Core\Context\Contract\IContextManager;
 use Imi\Core\Context\DefaultContextManager;
 use Imi\Server\Contract\IServer;
@@ -36,7 +37,7 @@ class RequestContext
     /**
      * 获取当前上下文标识.
      */
-    public static function getCurrentId(): string
+    public static function getCurrentId(): string|int
     {
         return static::getInstance()->getCurrentId();
     }
@@ -44,7 +45,7 @@ class RequestContext
     /**
      * 为当前请求创建上下文，返回当前协程ID.
      */
-    public static function create(array $data = []): \ArrayObject
+    public static function create(array $data = []): ContextData
     {
         $instance = static::getInstance();
 
@@ -54,7 +55,7 @@ class RequestContext
     /**
      * 销毁上下文.
      */
-    public static function destroy(?string $id = null): bool
+    public static function destroy(string|int|null $id = null): bool
     {
         $instance = static::getInstance();
 
@@ -64,7 +65,7 @@ class RequestContext
     /**
      * 上下文是否存在.
      */
-    public static function exists(string $id): bool
+    public static function exists(string|int $id): bool
     {
         return static::getInstance()->exists($id);
     }
@@ -137,10 +138,15 @@ class RequestContext
         }
     }
 
+    public static function defer(callable $callback): void
+    {
+        self::getContext()->defer($callback);
+    }
+
     /**
      * 获取当前上下文.
      */
-    public static function getContext(): \ArrayObject
+    public static function getContext(): ContextData
     {
         $instance = static::getInstance();
 

--- a/src/RequestContext.php
+++ b/src/RequestContext.php
@@ -36,9 +36,9 @@ class RequestContext
     /**
      * 获取当前上下文标识.
      */
-    public static function getCurrentFlag(): string
+    public static function getCurrentId(): string
     {
-        return static::getInstance()->getCurrentFlag();
+        return static::getInstance()->getCurrentId();
     }
 
     /**
@@ -48,25 +48,25 @@ class RequestContext
     {
         $instance = static::getInstance();
 
-        return $instance->create($instance->getCurrentFlag(), $data);
+        return $instance->create($instance->getCurrentId(), $data);
     }
 
     /**
      * 销毁上下文.
      */
-    public static function destroy(?string $flag = null): bool
+    public static function destroy(?string $id = null): bool
     {
         $instance = static::getInstance();
 
-        return $instance->destroy($flag ?? $instance->getCurrentFlag());
+        return $instance->destroy($id ?? $instance->getCurrentId());
     }
 
     /**
      * 上下文是否存在.
      */
-    public static function exists(string $flag): bool
+    public static function exists(string $id): bool
     {
-        return static::getInstance()->exists($flag);
+        return static::getInstance()->exists($id);
     }
 
     /**
@@ -75,7 +75,7 @@ class RequestContext
     public static function get(string $name, mixed $default = null): mixed
     {
         $instance = static::getInstance();
-        $context = $instance->get($instance->getCurrentFlag(), true);
+        $context = $instance->get($instance->getCurrentId(), true);
 
         return $context[$name] ?? $default;
     }
@@ -86,7 +86,7 @@ class RequestContext
     public static function set(string $name, mixed $value): void
     {
         $instance = static::getInstance();
-        $context = $instance->get($instance->getCurrentFlag(), true);
+        $context = $instance->get($instance->getCurrentId(), true);
         $context[$name] = $value;
     }
 
@@ -96,7 +96,7 @@ class RequestContext
     public static function muiltiSet(array $data): void
     {
         $instance = static::getInstance();
-        $context = $instance->get($instance->getCurrentFlag(), true);
+        $context = $instance->get($instance->getCurrentId(), true);
         foreach ($data as $k => $v)
         {
             $context[$k] = $v;
@@ -109,7 +109,7 @@ class RequestContext
     public static function use(callable $callback): mixed
     {
         $instance = static::getInstance();
-        $context = $instance->get($instance->getCurrentFlag(), true);
+        $context = $instance->get($instance->getCurrentId(), true);
 
         return $callback($context);
     }
@@ -144,7 +144,7 @@ class RequestContext
     {
         $instance = static::getInstance();
 
-        return $instance->get($instance->getCurrentFlag(), true);
+        return $instance->get($instance->getCurrentId(), true);
     }
 
     /**

--- a/tests/unit/Component/Tests/BaseLockTestCase.php
+++ b/tests/unit/Component/Tests/BaseLockTestCase.php
@@ -31,7 +31,7 @@ abstract class BaseLockTestCase extends BaseTest
             {
                 Assert::assertTrue($result);
                 Assert::assertTrue(Lock::isLocked($this->lockConfigId, $lockId));
-                Assert::assertEquals(RequestContext::getCurrentFlag(), Lock::getInstance($this->lockConfigId, $lockId)->getLockFlag());
+                Assert::assertEquals(RequestContext::getCurrentId(), Lock::getInstance($this->lockConfigId, $lockId)->getLockFlag());
             }
             finally
             {
@@ -54,7 +54,7 @@ abstract class BaseLockTestCase extends BaseTest
             {
                 Assert::assertTrue($result);
                 Assert::assertTrue(Lock::isLocked($this->lockConfigId, $lockId));
-                Assert::assertEquals(RequestContext::getCurrentFlag(), Lock::getInstance($this->lockConfigId, $lockId)->getLockFlag());
+                Assert::assertEquals(RequestContext::getCurrentId(), Lock::getInstance($this->lockConfigId, $lockId)->getLockFlag());
             }
             finally
             {
@@ -73,7 +73,7 @@ abstract class BaseLockTestCase extends BaseTest
             Assert::assertFalse(Lock::isLocked($this->lockConfigId, $lockId));
             $result = Lock::lock($this->lockConfigId, function () use ($lockId): void {
                 Assert::assertTrue(Lock::isLocked($this->lockConfigId, $lockId));
-                Assert::assertEquals(RequestContext::getCurrentFlag(), Lock::getInstance($this->lockConfigId, $lockId)->getLockFlag());
+                Assert::assertEquals(RequestContext::getCurrentId(), Lock::getInstance($this->lockConfigId, $lockId)->getLockFlag());
             }, null, $lockId);
             Assert::assertTrue($result);
             Assert::assertFalse(Lock::isLocked($this->lockConfigId, $lockId));
@@ -89,7 +89,7 @@ abstract class BaseLockTestCase extends BaseTest
             Assert::assertEquals('', Lock::getInstance($this->lockConfigId, $lockId)->getLockFlag());
             $result = Lock::tryLock($this->lockConfigId, function () use ($lockId): void {
                 Assert::assertTrue(Lock::isLocked($this->lockConfigId, $lockId));
-                Assert::assertEquals(RequestContext::getCurrentFlag(), Lock::getInstance($this->lockConfigId, $lockId)->getLockFlag());
+                Assert::assertEquals(RequestContext::getCurrentId(), Lock::getInstance($this->lockConfigId, $lockId)->getLockFlag());
             }, $lockId);
             Assert::assertTrue($result);
             Assert::assertFalse(Lock::isLocked($this->lockConfigId, $lockId));
@@ -107,7 +107,7 @@ abstract class BaseLockTestCase extends BaseTest
             $result = Lock::lock($this->lockConfigId, static function (): void {
                 Assert::assertTrue(false);
             }, function () use ($lockId) {
-                Assert::assertEquals(RequestContext::getCurrentFlag(), Lock::getInstance($this->lockConfigId, $lockId)->getLockFlag());
+                Assert::assertEquals(RequestContext::getCurrentId(), Lock::getInstance($this->lockConfigId, $lockId)->getLockFlag());
 
                 return true;
             }, $lockId);

--- a/tests/unit/Component/Tests/RequestContextTest.php
+++ b/tests/unit/Component/Tests/RequestContextTest.php
@@ -14,12 +14,15 @@ class RequestContextTest extends BaseTest
 {
     public function testDefer(): void
     {
-        $success = false;
-        RequestContext::defer(static function () use (&$success): void {
-            $success = true;
+        $result = [];
+        RequestContext::defer(static function () use (&$result): void {
+            $result[] = 1;
+        });
+        RequestContext::defer(static function () use (&$result): void {
+            $result[] = 2;
         });
         RequestContext::destroy();
-        $this->assertTrue($success);
+        $this->assertEquals([2, 1], $result);
     }
 
     public function testRemember(): void


### PR DESCRIPTION
* 把 `flag` 改名为 `id`
* 引入新的上下文对象类 `ContextData`，并支持所有环境下的 `defer()`
* Swoole 环境下的上下文，不直接使用 Swoole 上下文，也是使用 `ContextData`
* 计划废弃 `IMI.REQUEST_CONTENT.DESTROY` 事件，可以用 `defer()` 代替。将在连接中心代替旧版连接池后正式废弃！