### PR TITLE
优化数据库查询构建器：当 where 条件的值为 `NULL` 时，不使用参数绑定

### DIFF
--- a/src/Db/Drivers/TPdoStatement.php
+++ b/src/Db/Drivers/TPdoStatement.php
@@ -319,6 +319,14 @@ trait TPdoStatement
      */
     protected function getDataTypeByValue($value): int
     {
+        if (\is_int($value))
+        {
+            return \PDO::PARAM_INT;
+        }
+        if (\is_string($value))
+        {
+            return \PDO::PARAM_STR;
+        }
         if (null === $value)
         {
             return \PDO::PARAM_NULL;
@@ -326,10 +334,6 @@ trait TPdoStatement
         if (\is_bool($value))
         {
             return \PDO::PARAM_BOOL;
-        }
-        if (\is_int($value))
-        {
-            return \PDO::PARAM_INT;
         }
         if (\is_resource($value))
         {

--- a/src/Db/Query/Where/Where.php
+++ b/src/Db/Query/Where/Where.php
@@ -162,6 +162,10 @@ class Where extends BaseWhere implements IWhere
                 {
                     $result .= $thisValues->toString($query);
                 }
+                elseif (null === $thisValues)
+                {
+                    $result .= 'NULL';
+                }
                 else
                 {
                     $value = $query->getAutoParamName();

--- a/tests/unit/Component/Tests/Db/QueryCurdBaseTest.php
+++ b/tests/unit/Component/Tests/Db/QueryCurdBaseTest.php
@@ -867,4 +867,11 @@ abstract class QueryCurdBaseTest extends BaseTest
         $this->assertEquals([':p1' => 'imi', ':p2' => 0], $query->getBinds());
         $this->assertEquals(SearchModifier::WITH_QUERY_EXPANSION, $options->getSearchModifier());
     }
+
+    public function testWhereNull(): void
+    {
+        $query = Db::query()->from('test')->where('a', 'is', null);
+        $this->assertEquals('select * from `test` where `a` is NULL', $query->buildSelectSql());
+        $this->assertEquals([], $query->getBinds());
+    }
 }


### PR DESCRIPTION
MySQL 和 PostgreSQL 都不支持 `is NULL` 的 `NULL` 使用参数绑定传值。

`NULL` 是 SQL 标准关键字，直接拼接不会有兼容问题。

fix #669