### PR TITLE
[3.0] 连接中心一些改进

### DIFF
--- a/src/Components/connection-center/src/ConnectionCenter.php
+++ b/src/Components/connection-center/src/ConnectionCenter.php
@@ -98,7 +98,7 @@ class ConnectionCenter
                 }
             }
         }
-        if (null === $connection)
+        if (null === $connection || ConnectionStatus::Available !== $connection->getStatus())
         {
             $connection = $this->getConnection($name);
             $requestContext[static::class][$name] = [

--- a/src/Components/connection-center/src/Contract/IConnection.php
+++ b/src/Components/connection-center/src/Contract/IConnection.php
@@ -9,8 +9,14 @@ namespace Imi\ConnectionCenter\Contract;
  */
 use Imi\ConnectionCenter\Enum\ConnectionStatus;
 
+/**
+ * @template T of object
+ */
 interface IConnection
 {
+    /**
+     * @param T $instance
+     */
     public function __construct(IConnectionManager $manager, object $instance);
 
     /**
@@ -20,6 +26,8 @@ interface IConnection
 
     /**
      * 获取连接资源管理的对象实例.
+     *
+     * @return T
      */
     public function getInstance(): object;
 


### PR DESCRIPTION
- 对使用`RequestContext`获取的资源做手动释放后，避免获取到无效状态资源。
- 尝试使用泛型声明优化`IConnection`的`IDE`提示。

泛型例子  
![image](https://github.com/imiphp/imi/assets/14545600/35a074b6-3974-4dc7-ba43-06f3a94103a8)
![image](https://github.com/imiphp/imi/assets/14545600/55583969-7c20-4070-b669-56bf28e4d54f)
