### PR TITLE
修复MySQL8下更新JSON字段时出现的字符转换问题

### DIFF
--- a/src/Db/Mysql/Query/Builder/UpdateBuilder.php
+++ b/src/Db/Mysql/Query/Builder/UpdateBuilder.php
@@ -73,7 +73,7 @@ class UpdateBuilder extends BaseBuilder
                     {
                         $jsonSets[$field][] = [
                             'jsonKeywords' => $matches['jsonKeywords'],
-                            'raw'          => 'CONVERT(\'' . json_encode($v, \JSON_THROW_ON_ERROR | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE) . '\',JSON)',
+                            'raw'          => 'CAST(\'' . json_encode($v, \JSON_THROW_ON_ERROR | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE) . '\' AS JSON)',
                         ];
                     }
                 }


### PR DESCRIPTION
PDOException: SQLSTATE[22032]: <<Unknown error>>: 3144 Cannot create a JSON value from a string with CHARACTER SET 'binary'.