### PR TITLE
优化http表单POST请求getParsedBody对原始请求体的加载：移除在getParsedBody对原始body加载的逻辑

### DIFF
--- a/src/Util/Http/ServerRequest.php
+++ b/src/Util/Http/ServerRequest.php
@@ -286,11 +286,6 @@ class ServerRequest extends \Imi\Util\Http\Request implements IServerRequest
         $parsedBody = &$this->parsedBody;
         if (null === $parsedBody)
         {
-            if (!$this->bodyInited)
-            {
-                $this->initBody();
-                $this->bodyInited = true;
-            }
             $contentType = $this->getHeaderLine(RequestHeader::CONTENT_TYPE);
             if ('' === $contentType)
             {
@@ -311,7 +306,7 @@ class ServerRequest extends \Imi\Util\Http\Request implements IServerRequest
                 // json
                 elseif (MediaType::APPLICATION_JSON === $contentType)
                 {
-                    $content = $this->body->getContents();
+                    $content = $this->getBody()->getContents();
                     if ('' !== $content)
                     {
                         $parsedBody = json_decode($content, !Config::get('@currentServer.jsonBodyIsObject', false), 512, \JSON_THROW_ON_ERROR);
@@ -331,7 +326,7 @@ class ServerRequest extends \Imi\Util\Http\Request implements IServerRequest
                 ]))
                 {
                     $this->post = $parsedBody = new \DOMDocument();
-                    $parsedBody->loadXML($this->body->getContents());
+                    $parsedBody->loadXML($this->getBody()->getContents());
                 }
                 // 其它
                 else

--- a/tests/unit/Component/Tests/Util/Http/ServerRequestTest.php
+++ b/tests/unit/Component/Tests/Util/Http/ServerRequestTest.php
@@ -144,21 +144,14 @@ class ServerRequestTest extends BaseTest
         $this->assertEquals(['name' => 'imi'], $request->getParsedBody());
 
         // form
-        $request = new class() extends ServerRequest {
-            /**
-             * {@inheritDoc}
-             */
-            protected function initBody(): void
-            {
-                $this->post = ['name' => 'imi'];
-            }
-        };
+        $request = new ServerRequest();
         foreach ([
             MediaType::APPLICATION_FORM_URLENCODED,
             MediaType::MULTIPART_FORM_DATA,
         ] as $contentType)
         {
-            $request->setHeader(RequestHeader::CONTENT_TYPE, $contentType);
+            $request->setPost(['name' => 'imi'])
+                ->setHeader(RequestHeader::CONTENT_TYPE, $contentType);
             $requestTmp = $request->withMethod(RequestMethod::POST);
             $this->assertEquals(['name' => 'imi'], $requestTmp->getParsedBody());
             $requestTmp = $request->withMethod(RequestMethod::PUT);


### PR DESCRIPTION
直接从POST参数中获取，惰性加载原始Body，防止上传文件请求时直接加载整个文件二进制到内存中