### PR TITLE
修复oracle数据库ping语句

### DIFF
--- a/src/Db/Drivers/TPdoDriver.php
+++ b/src/Db/Drivers/TPdoDriver.php
@@ -82,7 +82,9 @@ trait TPdoDriver
         }
         try
         {
-            if ($instance->query('select 1'))
+            $driverName = $this->instance->getAttribute(\PDO::ATTR_DRIVER_NAME);
+            $is_oci = $driverName === 'oci';
+            if ($instance->query($is_oci ? 'select 1 from dual' : 'select 1'))
             {
                 return true;
             }

--- a/src/Db/Drivers/TPdoDriver.php
+++ b/src/Db/Drivers/TPdoDriver.php
@@ -83,7 +83,7 @@ trait TPdoDriver
         try
         {
             $driverName = $this->instance->getAttribute(\PDO::ATTR_DRIVER_NAME);
-            $is_oci = $driverName === 'oci';
+            $is_oci = 'oci' === $driverName;
             if ($instance->query($is_oci ? 'select 1 from dual' : 'select 1'))
             {
                 return true;


### PR DESCRIPTION
修复如下报错

```
[2026-01-21 12:00:31] imi.ERROR: syncKc2_error: SQLSTATE[HY000]: General error: 923 OCIStmtExecute: ORA-00923: FROM keyword not found where expected
 (/www/server/panel/install/pdo_oci/oci_statement.c:155)  
[2026-01-21 12:00:31] imi.ERROR: syncKc2_error 堆栈: #0 /xxx/vendor/imiphp/imi/src/Db/Drivers/TPdoDriver.php(85): PDO->query()
#1 /xxx/vendor/imiphp/imi/src/Db/Pool/DbResource.php(75): Imi\Db\Mysql\Drivers\PdoMysql\Driver->ping()
#2 /xxx/vendor/imiphp/imi/src/Pool/PoolManager.php(194): Imi\Db\Pool\DbResource->checkState()
#3 /xxx/vendor/imiphp/imi/src/Db/Db.php(70): Imi\Pool\PoolManager::getRequestContextResource()
#4 /xxx/Module/Test/Repository/Sales.php(353): Imi\Db\Db::getInstance()
```

Oracle 提供了一个名为 DUAL 的虚拟表（伪表），专门用于在不需要从实际数据表中取数时凑齐语法结构。DUAL 表是什么：DUAL 是系统自带的一个只有一个字段、一行记录的特殊表。当你执行 SELECT 1 FROM DUAL 时，它只会返回一行结果 1。