### PR TITLE
fix 修复hscasnEach变量名导致的作用域问题

### DIFF
--- a/src/Redis/RedisHandler.php
+++ b/src/Redis/RedisHandler.php
@@ -478,9 +478,9 @@ class RedisHandler
         {
             if ($result)
             {
-                foreach ($result as $key => $value)
+                foreach ($result as $field => $value)
                 {
-                    yield $key => $value;
+                    yield $field => $value;
                 }
             }
         }


### PR DESCRIPTION
RedisHandler下的hscanEach，$key变量同名导致的bug